### PR TITLE
chore: install ca-certificates to support https fetches which is not supported by alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.13
 
+RUN apk add --no-cache ca-certificates && update-ca-certificates
+
 COPY guardian .
 
 EXPOSE 8080


### PR DESCRIPTION
Got `x509: certificate signed by unknown authority` error when fetching to https IAM.
The base image we use `alpine` isn't supporting it hence adding it manually