### PR TITLE
fix: bug fixes

### DIFF
--- a/core/policy/service.go
+++ b/core/policy/service.go
@@ -221,6 +221,7 @@ func (s *Service) validateRequirements(requirements []*domain.Requirement) error
 				Role:       aa.Role,
 				Options:    aa.Options,
 			}
+			appeal.SetDefaults()
 			if err := s.providerService.ValidateAppeal(appeal, provider); err != nil {
 				return fmt.Errorf("requirement[%v].appeals[%v]: %w", i, j, err)
 			}

--- a/core/policy/service_test.go
+++ b/core/policy/service_test.go
@@ -526,6 +526,7 @@ func (s *ServiceTestSuite) TestPolicyRequirements() {
 							Role:       aa.Role,
 							Options:    aa.Options,
 						}
+						expectedAppeal.SetDefaults()
 						s.mockProviderService.
 							On("ValidateAppeal", expectedAppeal, expectedProvider).
 							Return(nil).

--- a/plugins/providers/bigquery/provider.go
+++ b/plugins/providers/bigquery/provider.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -118,6 +119,9 @@ func (p *Provider) GrantAccess(pc *domain.ProviderConfig, a *domain.Appeal) erro
 
 		for _, p := range permissions {
 			if err := bqClient.GrantDatasetAccess(ctx, d, a.AccountID, string(p)); err != nil {
+				if errors.Is(err, ErrPermissionAlreadyExists) {
+					return nil
+				}
 				return err
 			}
 		}
@@ -131,6 +135,9 @@ func (p *Provider) GrantAccess(pc *domain.ProviderConfig, a *domain.Appeal) erro
 
 		for _, p := range permissions {
 			if err := bqClient.GrantTableAccess(ctx, t, a.AccountType, a.AccountID, string(p)); err != nil {
+				if errors.Is(err, ErrPermissionAlreadyExists) {
+					return nil
+				}
 				return err
 			}
 		}
@@ -169,6 +176,9 @@ func (p *Provider) RevokeAccess(pc *domain.ProviderConfig, a *domain.Appeal) err
 
 		for _, p := range permissions {
 			if err := bqClient.RevokeDatasetAccess(ctx, d, a.AccountID, string(p)); err != nil {
+				if errors.Is(err, ErrPermissionNotFound) {
+					return nil
+				}
 				return err
 			}
 		}
@@ -182,6 +192,9 @@ func (p *Provider) RevokeAccess(pc *domain.ProviderConfig, a *domain.Appeal) err
 
 		for _, p := range permissions {
 			if err := bqClient.RevokeTableAccess(ctx, t, a.AccountType, a.AccountID, string(p)); err != nil {
+				if errors.Is(err, ErrPermissionNotFound) {
+					return nil
+				}
 				return err
 			}
 		}

--- a/plugins/providers/gcloudiam/provider.go
+++ b/plugins/providers/gcloudiam/provider.go
@@ -1,6 +1,7 @@
 package gcloudiam
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -74,7 +75,13 @@ func (p *Provider) GrantAccess(pc *domain.ProviderConfig, a *domain.Appeal) erro
 	}
 
 	if a.Resource.Type == ResourceTypeProject || a.Resource.Type == ResourceTypeOrganization {
-		return client.GrantAccess(a.AccountType, a.AccountID, a.Role)
+		if err := client.GrantAccess(a.AccountType, a.AccountID, a.Role); err != nil {
+			if errors.Is(err, ErrPermissionAlreadyExists) {
+				return nil
+			}
+			return err
+		}
+		return nil
 	}
 
 	return ErrInvalidResourceType
@@ -92,7 +99,13 @@ func (p *Provider) RevokeAccess(pc *domain.ProviderConfig, a *domain.Appeal) err
 	}
 
 	if a.Resource.Type == ResourceTypeProject || a.Resource.Type == ResourceTypeOrganization {
-		return client.RevokeAccess(a.AccountType, a.AccountID, a.Role)
+		if err := client.RevokeAccess(a.AccountType, a.AccountID, a.Role); err != nil {
+			if errors.Is(err, ErrPermissionNotFound) {
+				return nil
+			}
+			return err
+		}
+		return nil
 	}
 
 	return ErrInvalidResourceType

--- a/store/model/appeal.go
+++ b/store/model/appeal.go
@@ -102,6 +102,9 @@ func (m *Appeal) FromDomain(a *domain.Appeal) error {
 	m.Options = datatypes.JSON(options)
 	m.Labels = datatypes.JSON(labels)
 	m.Details = datatypes.JSON(details)
+	m.RevokedBy = a.RevokedBy
+	m.RevokedAt = a.RevokedAt
+	m.RevokeReason = a.RevokeReason
 	m.Approvals = approvals
 	m.CreatedAt = a.CreatedAt
 	m.UpdatedAt = a.UpdatedAt
@@ -172,6 +175,9 @@ func (m *Appeal) ToDomain() (*domain.Appeal, error) {
 		Role:          m.Role,
 		Options:       options,
 		Details:       details,
+		RevokedBy:     m.RevokedBy,
+		RevokedAt:     m.RevokedAt,
+		RevokeReason:  m.RevokeReason,
 		Labels:        labels,
 		Approvals:     approvals,
 		Resource:      resource,

--- a/store/postgres/policy_repository_test.go
+++ b/store/postgres/policy_repository_test.go
@@ -39,6 +39,7 @@ func (s *PolicyRepositoryTestSuite) SetupTest() {
 		"description",
 		"steps",
 		"labels",
+		"requirements",
 		"iam",
 		"created_at",
 		"updated_at",
@@ -50,7 +51,7 @@ func (s *PolicyRepositoryTestSuite) TearDownTest() {
 }
 
 func (s *PolicyRepositoryTestSuite) TestCreate() {
-	expectedQuery := regexp.QuoteMeta(`INSERT INTO "policies" ("id","version","description","steps","labels","iam","created_at","updated_at","deleted_at") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`)
+	expectedQuery := regexp.QuoteMeta(`INSERT INTO "policies" ("id","version","description","steps","labels","requirements","iam","created_at","updated_at","deleted_at") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`)
 
 	s.Run("should return error if got error from db transaction", func() {
 		p := &domain.Policy{}
@@ -59,6 +60,7 @@ func (s *PolicyRepositoryTestSuite) TestCreate() {
 			p.ID,
 			p.Version,
 			p.Description,
+			"null",
 			"null",
 			"null",
 			"null",
@@ -86,6 +88,7 @@ func (s *PolicyRepositoryTestSuite) TestCreate() {
 			p.ID,
 			p.Version,
 			p.Description,
+			"null",
 			"null",
 			"null",
 			"null",
@@ -138,6 +141,7 @@ func (s *PolicyRepositoryTestSuite) TestFind() {
 				"",
 				1,
 				"",
+				"null",
 				"null",
 				"null",
 				"null",
@@ -209,6 +213,7 @@ func (s *PolicyRepositoryTestSuite) TestGetOne() {
 					tc.expectedID,
 					tc.expectedVersion,
 					"",
+					"null",
 					"null",
 					"null",
 					"null",


### PR DESCRIPTION
- assign appeal's default values when validating requirements in policy creation
- add missing revoke info fields in model adapter
- store requirements config properly
- ignore "permission exists" error during granting permission to sync the appeal state
- ignore "permission not found" error during revoking permission to sync the appeal state
- change `format` flag to `output` in resource sub-commands