### PR TITLE
fix(appeal): appeal fixes and refactor

### DIFF
--- a/api/handler/v1beta1/grpc.go
+++ b/api/handler/v1beta1/grpc.go
@@ -362,7 +362,7 @@ func (s *GRPCServer) ListUserAppeals(ctx context.Context, req *guardianv1beta1.L
 	}
 
 	filters := &domain.ListAppealsFilter{
-		AccountID: user,
+		CreatedBy: user,
 	}
 	if req.GetStatuses() != nil {
 		filters.Statuses = req.GetStatuses()

--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -90,13 +90,18 @@ func (s *Service) Create(appeals []*domain.Appeal) error {
 	if err != nil {
 		return err
 	}
-	pendingAppeals, activeAppeals, err := s.getExistingAppealsMap()
+
+	appealsGroupedByStatus, err := s.getAppealsMapGroupedByStatus([]string{
+		domain.AppealStatusPending,
+		domain.AppealStatusActive,
+	})
 	if err != nil {
 		return err
 	}
+	pendingAppeals := appealsGroupedByStatus[domain.AppealStatusPending]
+	activeAppeals := appealsGroupedByStatus[domain.AppealStatusActive]
 
 	notifications := []domain.Notification{}
-	expiredAppeals := []*domain.Appeal{}
 
 	for _, appeal := range appeals {
 		appeal.SetDefaults()
@@ -112,12 +117,12 @@ func (s *Service) Create(appeals []*domain.Appeal) error {
 			return fmt.Errorf("retrieving provider: %w", err)
 		}
 
-		expiredAppeal, err := s.checkAppealExtension(appeal, provider, activeAppeals)
+		ok, err := s.isEligibleToExtend(appeal, provider, activeAppeals)
 		if err != nil {
-			return fmt.Errorf("checking appeal extension: %w", err)
+			return fmt.Errorf("checking appeal extension eligibility: %w", err)
 		}
-		if expiredAppeal != nil {
-			expiredAppeals = append(expiredAppeals, expiredAppeal)
+		if !ok {
+			return ErrAppealNotEligibleForExtension
 		}
 
 		if err := s.providerService.ValidateAppeal(appeal, provider); err != nil {
@@ -166,8 +171,7 @@ func (s *Service) Create(appeals []*domain.Appeal) error {
 		}
 	}
 
-	allAppeals := append(appeals, expiredAppeals...)
-	if err := s.repo.BulkUpsert(allAppeals); err != nil {
+	if err := s.repo.BulkUpsert(appeals); err != nil {
 		return fmt.Errorf("inserting appeals into db: %w", err)
 	}
 
@@ -219,6 +223,7 @@ func (s *Service) MakeAction(approvalAction domain.ApprovalAction) (*domain.Appe
 			approval.Reason = approvalAction.Reason
 			approval.UpdatedAt = TimeNow()
 
+			var oldExtendedAppeal *domain.Appeal
 			if approvalAction.Action == domain.AppealActionNameApprove {
 				approval.Status = domain.ApprovalStatusApproved
 				if i+1 <= len(appeal.Approvals)-1 {
@@ -229,8 +234,22 @@ func (s *Service) MakeAction(approvalAction domain.ApprovalAction) (*domain.Appe
 				}
 
 				if i == len(appeal.Approvals)-1 {
-					if err := s.createAccess(appeal); err != nil {
-						return nil, err
+					activeAppeals, err := s.repo.Find(&domain.ListAppealsFilter{
+						AccountID:  appeal.AccountID,
+						ResourceID: appeal.ResourceID,
+						Role:       appeal.Role,
+						Statuses:   []string{domain.AppealStatusActive},
+					})
+					if err != nil {
+						return nil, fmt.Errorf("unable to retrieve existing active appeal from db: %w", err)
+					}
+					if len(activeAppeals) > 0 {
+						oldExtendedAppeal = activeAppeals[0]
+						oldExtendedAppeal.Terminate()
+					} else {
+						if err := s.createAccess(appeal); err != nil {
+							return nil, err
+						}
 					}
 				}
 			} else if approvalAction.Action == domain.AppealActionNameReject {
@@ -247,6 +266,11 @@ func (s *Service) MakeAction(approvalAction domain.ApprovalAction) (*domain.Appe
 				return nil, ErrActionInvalidValue
 			}
 
+			if oldExtendedAppeal != nil {
+				if err := s.repo.Update(oldExtendedAppeal); err != nil {
+					return nil, fmt.Errorf("failed to update existing active appeal: %w", err)
+				}
+			}
 			if err := s.repo.Update(appeal); err != nil {
 				if err := s.providerService.RevokeAccess(appeal); err != nil {
 					return nil, err
@@ -353,37 +377,28 @@ func (s *Service) Revoke(id string, actor, reason string) (*domain.Appeal, error
 	return revokedAppeal, nil
 }
 
-func (s *Service) getExistingAppealsMap() (map[string]map[string]map[string]*domain.Appeal, map[string]map[string]map[string]*domain.Appeal, error) {
-	appeals, err := s.repo.Find(&domain.ListAppealsFilter{
-		Statuses: []string{domain.AppealStatusPending, domain.AppealStatusActive},
-	})
+// getAppealsMapGroupedByStatus returns map[status]map[account_id]map[resource_id]map[role]*domain.Appeal, error
+func (s *Service) getAppealsMapGroupedByStatus(statuses []string) (map[string]map[string]map[string]map[string]*domain.Appeal, error) {
+	appeals, err := s.repo.Find(&domain.ListAppealsFilter{Statuses: statuses})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	pendingAppealsMap := map[string]map[string]map[string]*domain.Appeal{}
-	activeAppealsMap := map[string]map[string]map[string]*domain.Appeal{}
+	appealsMap := map[string]map[string]map[string]map[string]*domain.Appeal{}
 	for _, a := range appeals {
-		if a.Status == domain.AppealStatusPending {
-			if pendingAppealsMap[a.AccountID] == nil {
-				pendingAppealsMap[a.AccountID] = map[string]map[string]*domain.Appeal{}
-			}
-			if pendingAppealsMap[a.AccountID][a.ResourceID] == nil {
-				pendingAppealsMap[a.AccountID][a.ResourceID] = map[string]*domain.Appeal{}
-			}
-			pendingAppealsMap[a.AccountID][a.ResourceID][a.Role] = a
-		} else if a.Status == domain.AppealStatusActive {
-			if activeAppealsMap[a.AccountID] == nil {
-				activeAppealsMap[a.AccountID] = map[string]map[string]*domain.Appeal{}
-			}
-			if activeAppealsMap[a.AccountID][a.ResourceID] == nil {
-				activeAppealsMap[a.AccountID][a.ResourceID] = map[string]*domain.Appeal{}
-			}
-			activeAppealsMap[a.AccountID][a.ResourceID][a.Role] = a
+		if appealsMap[a.Status] == nil {
+			appealsMap[a.Status] = map[string]map[string]map[string]*domain.Appeal{}
 		}
+		if appealsMap[a.Status][a.AccountID] == nil {
+			appealsMap[a.Status][a.AccountID] = map[string]map[string]*domain.Appeal{}
+		}
+		if appealsMap[a.Status][a.AccountID][a.ResourceID] == nil {
+			appealsMap[a.Status][a.AccountID][a.ResourceID] = map[string]*domain.Appeal{}
+		}
+		appealsMap[a.Status][a.AccountID][a.ResourceID][a.Role] = a
 	}
 
-	return pendingAppealsMap, activeAppealsMap, nil
+	return appealsMap, nil
 }
 
 func (s *Service) getResourcesMap(ids []string) (map[string]*domain.Resource, error) {
@@ -683,34 +698,28 @@ func (s *Service) createAccess(a *domain.Appeal) error {
 	return nil
 }
 
-func (s *Service) checkAppealExtension(a *domain.Appeal, p *domain.Provider, activeAppealsMap map[string]map[string]map[string]*domain.Appeal) (*domain.Appeal, error) {
+func (s *Service) isEligibleToExtend(a *domain.Appeal, p *domain.Provider, activeAppealsMap map[string]map[string]map[string]*domain.Appeal) (bool, error) {
 	if activeAppealsMap[a.AccountID] != nil &&
 		activeAppealsMap[a.AccountID][a.ResourceID] != nil &&
 		activeAppealsMap[a.AccountID][a.ResourceID][a.Role] != nil {
 		if p.Config.Appeal != nil {
 			if p.Config.Appeal.AllowActiveAccessExtensionIn == "" {
-				return nil, ErrAppealFoundActiveAccess
+				return false, ErrAppealFoundActiveAccess
 			}
 
 			duration, err := time.ParseDuration(p.Config.Appeal.AllowActiveAccessExtensionIn)
 			if err != nil {
-				return nil, fmt.Errorf("%v: %v: %v", ErrAppealInvalidExtensionDuration, p.Config.Appeal.AllowActiveAccessExtensionIn, err)
+				return false, fmt.Errorf("%v: %v: %v", ErrAppealInvalidExtensionDuration, p.Config.Appeal.AllowActiveAccessExtensionIn, err)
 			}
 
 			now := s.TimeNow()
 			activeAppealExpDate := activeAppealsMap[a.AccountID][a.ResourceID][a.Role].Options.ExpirationDate
 			isEligibleForExtension := activeAppealExpDate.Sub(now) <= duration
-			if isEligibleForExtension {
-				oldAppeal := &domain.Appeal{}
-				*oldAppeal = *activeAppealsMap[a.AccountID][a.ResourceID][a.Role]
-				oldAppeal.Terminate()
-				return oldAppeal, nil
-			} else {
-				return nil, fmt.Errorf("%v: the extension policy for this resource is %v before current access expiration", ErrAppealNotEligibleForExtension, duration)
-			}
+			return isEligibleForExtension, nil
 		}
 	}
-	return nil, nil
+
+	return true, nil
 }
 
 func getPolicy(a *domain.Appeal, p *domain.Provider, policiesMap map[string]map[uint]*domain.Policy) (*domain.Policy, error) {

--- a/domain/appeal.go
+++ b/domain/appeal.go
@@ -97,6 +97,7 @@ type ApprovalAction struct {
 }
 
 type ListAppealsFilter struct {
+	CreatedBy                 string    `mapstructure:"created_by" validate:"omitempty,required"`
 	AccountID                 string    `mapstructure:"account_id" validate:"omitempty,required"`
 	ResourceID                string    `mapstructure:"resource_id" validate:"omitempty,required"`
 	Role                      string    `mapstructure:"role" validate:"omitempty,required"`

--- a/domain/appeal.go
+++ b/domain/appeal.go
@@ -62,8 +62,14 @@ func (a *Appeal) GetNextPendingApproval() *Approval {
 	return nil
 }
 
-func (a *Appeal) Terminate() {
-	a.Status = AppealStatusTerminated
+func (a *Appeal) Init(policy *Policy) {
+	a.Status = AppealStatusPending
+	a.PolicyID = policy.ID
+	a.PolicyVersion = policy.Version
+}
+
+func (a *Appeal) Cancel() {
+	a.Status = AppealStatusCanceled
 }
 
 func (a *Appeal) Activate() error {
@@ -80,6 +86,14 @@ func (a *Appeal) Activate() error {
 	}
 
 	return nil
+}
+
+func (a *Appeal) Reject() {
+	a.Status = AppealStatusRejected
+}
+
+func (a *Appeal) Terminate() {
+	a.Status = AppealStatusTerminated
 }
 
 func (a *Appeal) SetDefaults() {

--- a/domain/approval.go
+++ b/domain/approval.go
@@ -1,6 +1,9 @@
 package domain
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 const (
 	ApprovalStatusPending  = "pending"
@@ -26,6 +29,36 @@ type Approval struct {
 
 	CreatedAt time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+}
+
+func (a *Approval) Init(policy *Policy, index int, approvers []string) error {
+	if index > len(policy.Steps)-1 {
+		return errors.New("approval step index out of range")
+	}
+	approvalStep := policy.Steps[index]
+
+	a.Status = ApprovalStatusPending
+	if index > 0 {
+		a.Status = ApprovalStatusBlocked
+	}
+	a.Index = index
+	a.Name = approvalStep.Name
+	a.PolicyID = policy.ID
+	a.PolicyVersion = policy.Version
+	a.Approvers = approvers
+	return nil
+}
+
+func (a *Approval) Approve() {
+	a.Status = ApprovalStatusApproved
+}
+
+func (a *Approval) Reject() {
+	a.Status = ApprovalStatusRejected
+}
+
+func (a *Approval) Skip() {
+	a.Status = ApprovalStatusSkipped
 }
 
 func (a *Approval) IsManualApproval() bool {

--- a/store/postgres/appeal_repository.go
+++ b/store/postgres/appeal_repository.go
@@ -63,6 +63,9 @@ func (r *AppealRepository) Find(filters *domain.ListAppealsFilter) ([]*domain.Ap
 	}
 
 	db := r.db
+	if filters.CreatedBy != "" {
+		db = db.Where(`"created_by" = ?`, filters.CreatedBy)
+	}
 	if filters.AccountID != "" {
 		db = db.Where(`"account_id" = ?`, filters.AccountID)
 	}

--- a/store/postgres/appeal_repository_test.go
+++ b/store/postgres/appeal_repository_test.go
@@ -263,6 +263,13 @@ func (s *AppealRepositoryTestSuite) TestFind() {
 			},
 			{
 				filters: &domain.ListAppealsFilter{
+					CreatedBy: "user@email.com",
+				},
+				expectedClauseQuery: `"created_by" = $1 AND "appeals"."deleted_at" IS NULL`,
+				expectedArgs:        []driver.Value{"user@email.com"},
+			},
+			{
+				filters: &domain.ListAppealsFilter{
 					AccountID: "user@email.com",
 				},
 				expectedClauseQuery: `"account_id" = $1 AND "appeals"."deleted_at" IS NULL`,


### PR DESCRIPTION
Changes: 
- filter `/me/appeals` endpoints based on `created_by` instead of `account_id`
- terminate existing active appeal when new approval is approved instead of created