### PR TITLE
fix(cmd): load `host` from flag for core commands

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/odpf/guardian/plugins/notifiers"
 	"github.com/odpf/guardian/store"
-	"github.com/odpf/salt/cmdx"
 	"github.com/odpf/salt/config"
 )
 
@@ -18,10 +17,6 @@ type Config struct {
 	DB                         store.Config     `mapstructure:"db"`
 	AuthenticatedUserHeaderKey string           `mapstructure:"authenticated_user_header_key"`
 	Jobs                       Jobs             `mapstructure:"jobs"`
-}
-
-type CLIConfig struct {
-	Host string `mapstructure:"host" default:"localhost"`
 }
 
 func LoadConfig(configFile string) (Config, error) {
@@ -36,13 +31,4 @@ func LoadConfig(configFile string) (Config, error) {
 		return Config{}, err
 	}
 	return cfg, nil
-}
-
-func LoadCLIConfig() (*CLIConfig, error) {
-	var config CLIConfig
-
-	cfg := cmdx.SetConfig("guardian")
-	err := cfg.Load(&config)
-
-	return &config, err
 }

--- a/cmd/appeal.go
+++ b/cmd/appeal.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	guardianv1beta1 "github.com/odpf/guardian/api/proto/odpf/guardian/v1beta1"
-	"github.com/odpf/guardian/app"
 	"github.com/odpf/guardian/domain"
 	"github.com/odpf/salt/printer"
 	"github.com/odpf/salt/term"
@@ -16,7 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func appealsCommand(c *app.CLIConfig) *cobra.Command {
+func appealsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "appeal",
 		Aliases: []string{"appeals"},
@@ -35,18 +33,18 @@ func appealsCommand(c *app.CLIConfig) *cobra.Command {
 		`),
 	}
 
-	cmd.AddCommand(listAppealsCommand(c))
-	cmd.AddCommand(createAppealCommand(c))
-	cmd.AddCommand(revokeAppealCommand(c))
-	cmd.AddCommand(approveApprovalStepCommand(c))
-	cmd.AddCommand(rejectApprovalStepCommand(c))
-	cmd.AddCommand(statusAppealCommand(c))
-	cmd.AddCommand(cancelAppealCommand(c))
+	cmd.AddCommand(listAppealsCommand())
+	cmd.AddCommand(createAppealCommand())
+	cmd.AddCommand(revokeAppealCommand())
+	cmd.AddCommand(approveApprovalStepCommand())
+	cmd.AddCommand(rejectApprovalStepCommand())
+	cmd.AddCommand(statusAppealCommand())
+	cmd.AddCommand(cancelAppealCommand())
 
 	return cmd
 }
 
-func listAppealsCommand(c *app.CLIConfig) *cobra.Command {
+func listAppealsCommand() *cobra.Command {
 	var statuses []string
 	var role string
 	var accountID string
@@ -65,14 +63,13 @@ func listAppealsCommand(c *app.CLIConfig) *cobra.Command {
 
 			cs := term.NewColorScheme()
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
-			res, err := client.ListAppeals(ctx, &guardianv1beta1.ListAppealsRequest{
+			res, err := client.ListAppeals(cmd.Context(), &guardianv1beta1.ListAppealsRequest{
 				Statuses:  statuses,
 				Role:      role,
 				AccountId: accountID,
@@ -110,7 +107,7 @@ func listAppealsCommand(c *app.CLIConfig) *cobra.Command {
 	return cmd
 }
 
-func createAppealCommand(c *app.CLIConfig) *cobra.Command {
+func createAppealCommand() *cobra.Command {
 	var accountID, accountType, resourceID, role, optionsDuration string
 
 	cmd := &cobra.Command{
@@ -133,14 +130,13 @@ func createAppealCommand(c *app.CLIConfig) *cobra.Command {
 				return err
 			}
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
-			res, err := client.CreateAppeal(ctx, &guardianv1beta1.CreateAppealRequest{
+			res, err := client.CreateAppeal(cmd.Context(), &guardianv1beta1.CreateAppealRequest{
 				AccountId:   accountID,
 				AccountType: accountType,
 				Resources: []*guardianv1beta1.CreateAppealRequest_Resource{
@@ -181,7 +177,7 @@ func createAppealCommand(c *app.CLIConfig) *cobra.Command {
 	return cmd
 }
 
-func revokeAppealCommand(c *app.CLIConfig) *cobra.Command {
+func revokeAppealCommand() *cobra.Command {
 	var reason string
 
 	cmd := &cobra.Command{
@@ -196,15 +192,14 @@ func revokeAppealCommand(c *app.CLIConfig) *cobra.Command {
 			spinner := printer.Spin("")
 			defer spinner.Stop()
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
 			id := args[0]
-			_, err = client.RevokeAppeal(ctx, &guardianv1beta1.RevokeAppealRequest{
+			_, err = client.RevokeAppeal(cmd.Context(), &guardianv1beta1.RevokeAppealRequest{
 				Id: id,
 				Reason: &guardianv1beta1.RevokeAppealRequest_Reason{
 					Reason: reason,
@@ -227,7 +222,7 @@ func revokeAppealCommand(c *app.CLIConfig) *cobra.Command {
 	return cmd
 }
 
-func approveApprovalStepCommand(c *app.CLIConfig) *cobra.Command {
+func approveApprovalStepCommand() *cobra.Command {
 	var approvalName string
 
 	cmd := &cobra.Command{
@@ -241,15 +236,14 @@ func approveApprovalStepCommand(c *app.CLIConfig) *cobra.Command {
 			spinner := printer.Spin("")
 			defer spinner.Stop()
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
 			id := args[0]
-			_, err = client.UpdateApproval(ctx, &guardianv1beta1.UpdateApprovalRequest{
+			_, err = client.UpdateApproval(cmd.Context(), &guardianv1beta1.UpdateApprovalRequest{
 				Id:           id,
 				ApprovalName: approvalName,
 				Action: &guardianv1beta1.UpdateApprovalRequest_Action{
@@ -274,7 +268,7 @@ func approveApprovalStepCommand(c *app.CLIConfig) *cobra.Command {
 	return cmd
 }
 
-func rejectApprovalStepCommand(c *app.CLIConfig) *cobra.Command {
+func rejectApprovalStepCommand() *cobra.Command {
 	var approvalName string
 
 	cmd := &cobra.Command{
@@ -288,15 +282,14 @@ func rejectApprovalStepCommand(c *app.CLIConfig) *cobra.Command {
 			spinner := printer.Spin("")
 			defer spinner.Stop()
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
 			id := args[0]
-			_, err = client.UpdateApproval(ctx, &guardianv1beta1.UpdateApprovalRequest{
+			_, err = client.UpdateApproval(cmd.Context(), &guardianv1beta1.UpdateApprovalRequest{
 				Id:           id,
 				ApprovalName: approvalName,
 				Action: &guardianv1beta1.UpdateApprovalRequest_Action{
@@ -321,7 +314,7 @@ func rejectApprovalStepCommand(c *app.CLIConfig) *cobra.Command {
 	return cmd
 }
 
-func statusAppealCommand(c *app.CLIConfig) *cobra.Command {
+func statusAppealCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Approval status of an appeal",
@@ -333,15 +326,14 @@ func statusAppealCommand(c *app.CLIConfig) *cobra.Command {
 			spinner := printer.Spin("")
 			defer spinner.Stop()
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
 			id := args[0]
-			res, err := client.GetAppeal(ctx, &guardianv1beta1.GetAppealRequest{
+			res, err := client.GetAppeal(cmd.Context(), &guardianv1beta1.GetAppealRequest{
 				Id: id,
 			})
 			if err != nil {
@@ -388,7 +380,7 @@ func statusAppealCommand(c *app.CLIConfig) *cobra.Command {
 	return cmd
 }
 
-func cancelAppealCommand(c *app.CLIConfig) *cobra.Command {
+func cancelAppealCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cancel",
 		Short: "Cancel an appeal",
@@ -400,15 +392,14 @@ func cancelAppealCommand(c *app.CLIConfig) *cobra.Command {
 			spinner := printer.Spin("")
 			defer spinner.Stop()
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
 			id := args[0]
-			_, err = client.CancelAppeal(ctx, &guardianv1beta1.CancelAppealRequest{
+			_, err = client.CancelAppeal(cmd.Context(), &guardianv1beta1.CancelAppealRequest{
 				Id: id,
 			})
 			if err != nil {

--- a/cmd/appeal.go
+++ b/cmd/appeal.go
@@ -40,6 +40,7 @@ func appealsCommand() *cobra.Command {
 	cmd.AddCommand(rejectApprovalStepCommand())
 	cmd.AddCommand(statusAppealCommand())
 	cmd.AddCommand(cancelAppealCommand())
+	bindFlagsFromConfig(cmd)
 
 	return cmd
 }

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	guardianv1beta1 "github.com/odpf/guardian/api/proto/odpf/guardian/v1beta1"
+	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 )
 
@@ -17,8 +19,16 @@ func createConnection(ctx context.Context, host string) (*grpc.ClientConn, error
 	return grpc.DialContext(ctx, host, opts...)
 }
 
-func createClient(ctx context.Context, host string) (guardianv1beta1.GuardianServiceClient, func(), error) {
-	dialTimeoutCtx, dialCancel := context.WithTimeout(ctx, time.Second*2)
+func createClient(cmd *cobra.Command) (guardianv1beta1.GuardianServiceClient, func(), error) {
+	host, err := cmd.Flags().GetString("host")
+	if err != nil {
+		return nil, nil, err
+	}
+	if host == "" {
+		return nil, nil, errors.New("\"host\" not set")
+	}
+
+	dialTimeoutCtx, dialCancel := context.WithTimeout(cmd.Context(), time.Second*2)
 	conn, err := createConnection(dialTimeoutCtx, host)
 	if err != nil {
 		dialCancel()

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var cliConfig *Config
+
 type Config struct {
 	Host string `mapstructure:"host"`
 }
@@ -21,16 +23,14 @@ func LoadConfig() (*Config, error) {
 	return &config, err
 }
 
-func BindFlagsFromConfig(cmd *cobra.Command, cfg *Config) error {
+func bindFlagsFromConfig(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP("host", "H", "", "Guardian service to connect to")
 
-	if cfg.Host != "" {
-		if err := cmd.PersistentFlags().Set("host", cfg.Host); err != nil {
-			return err
+	if cliConfig != nil {
+		if cliConfig.Host != "" {
+			cmd.PersistentFlags().Set("host", cliConfig.Host)
 		}
 	}
-
-	return nil
 }
 
 func configCommand() *cobra.Command {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,10 +4,34 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/odpf/guardian/app"
 	"github.com/odpf/salt/cmdx"
 	"github.com/spf13/cobra"
 )
+
+type Config struct {
+	Host string `mapstructure:"host"`
+}
+
+func LoadConfig() (*Config, error) {
+	var config Config
+
+	cfg := cmdx.SetConfig("guardian")
+	err := cfg.Load(&config)
+
+	return &config, err
+}
+
+func BindFlagsFromConfig(cmd *cobra.Command, cfg *Config) error {
+	cmd.PersistentFlags().StringP("host", "H", "", "Guardian service to connect to")
+
+	if cfg.Host != "" {
+		if err := cmd.PersistentFlags().Set("host", cfg.Host); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 func configCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +61,7 @@ func configInitCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := cmdx.SetConfig("guardian")
 
-			if err := cfg.Init(&app.CLIConfig{}); err != nil {
+			if err := cfg.Init(&Config{}); err != nil {
 				return err
 			}
 

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -12,7 +11,6 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	handlerv1beta1 "github.com/odpf/guardian/api/handler/v1beta1"
 	guardianv1beta1 "github.com/odpf/guardian/api/proto/odpf/guardian/v1beta1"
-	"github.com/odpf/guardian/app"
 	"github.com/odpf/guardian/domain"
 	"github.com/odpf/salt/printer"
 	"github.com/odpf/salt/term"
@@ -23,7 +21,7 @@ import (
 )
 
 // PolicyCmd is the root command for the policies subcommand.
-func PolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
+func PolicyCmd(adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "policy",
 		Aliases: []string{"policies"},
@@ -44,18 +42,18 @@ func PolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.Com
 		},
 	}
 
-	cmd.AddCommand(listPoliciesCmd(c))
-	cmd.AddCommand(getPolicyCmd(c, adapter))
-	cmd.AddCommand(createPolicyCmd(c, adapter))
-	cmd.AddCommand(updatePolicyCmd(c, adapter))
-	cmd.AddCommand(planPolicyCmd(c, adapter))
-	cmd.AddCommand(applyPolicyCmd(c, adapter))
-	cmd.AddCommand(initPolicyCmd(c))
+	cmd.AddCommand(listPoliciesCmd())
+	cmd.AddCommand(getPolicyCmd(adapter))
+	cmd.AddCommand(createPolicyCmd(adapter))
+	cmd.AddCommand(updatePolicyCmd(adapter))
+	cmd.AddCommand(planPolicyCmd(adapter))
+	cmd.AddCommand(applyPolicyCmd(adapter))
+	cmd.AddCommand(initPolicyCmd())
 
 	return cmd
 }
 
-func listPoliciesCmd(c *app.CLIConfig) *cobra.Command {
+func listPoliciesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List and filter access policies",
@@ -74,14 +72,13 @@ func listPoliciesCmd(c *app.CLIConfig) *cobra.Command {
 
 			cs := term.NewColorScheme()
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
-			res, err := client.ListPolicies(ctx, &guardianv1beta1.ListPoliciesRequest{})
+			res, err := client.ListPolicies(cmd.Context(), &guardianv1beta1.ListPoliciesRequest{})
 			if err != nil {
 				return err
 			}
@@ -114,7 +111,7 @@ func listPoliciesCmd(c *app.CLIConfig) *cobra.Command {
 	}
 }
 
-func getPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
+func getPolicyCmd(adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
 	var format, versionFlag string
 
 	cmd := &cobra.Command{
@@ -139,8 +136,7 @@ func getPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.
 			spinner := printer.Spin("")
 			defer spinner.Stop()
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
@@ -154,7 +150,7 @@ func getPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.
 				return err
 			}
 
-			res, err := client.GetPolicy(ctx, &guardianv1beta1.GetPolicyRequest{
+			res, err := client.GetPolicy(cmd.Context(), &guardianv1beta1.GetPolicyRequest{
 				Id:      id,
 				Version: uint32(version),
 			})
@@ -182,7 +178,7 @@ func getPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.
 	return cmd
 }
 
-func createPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
+func createPolicyCmd(adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
 	var filePath string
 
 	cmd := &cobra.Command{
@@ -211,14 +207,13 @@ func createPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cob
 				return err
 			}
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
-			res, err := client.CreatePolicy(ctx, &guardianv1beta1.CreatePolicyRequest{
+			res, err := client.CreatePolicy(cmd.Context(), &guardianv1beta1.CreatePolicyRequest{
 				Policy: policyProto,
 			})
 			if err != nil {
@@ -239,7 +234,7 @@ func createPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cob
 	return cmd
 }
 
-func updatePolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
+func updatePolicyCmd(adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
 	var filePath string
 	cmd := &cobra.Command{
 		Use:   "edit",
@@ -268,15 +263,14 @@ func updatePolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cob
 				return err
 			}
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
 			policyID := policyProto.GetId()
-			_, err = client.UpdatePolicy(ctx, &guardianv1beta1.UpdatePolicyRequest{
+			_, err = client.UpdatePolicy(cmd.Context(), &guardianv1beta1.UpdatePolicyRequest{
 				Id:     policyID,
 				Policy: policyProto,
 			})
@@ -298,7 +292,7 @@ func updatePolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cob
 	return cmd
 }
 
-func initPolicyCmd(c *app.CLIConfig) *cobra.Command {
+func initPolicyCmd() *cobra.Command {
 	var file string
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -334,7 +328,7 @@ func initPolicyCmd(c *app.CLIConfig) *cobra.Command {
 	return cmd
 }
 
-func applyPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
+func applyPolicyCmd(adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
 	var filePath string
 
 	cmd := &cobra.Command{
@@ -363,15 +357,14 @@ func applyPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobr
 				return err
 			}
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
 			policyID := policyProto.GetId()
-			_, err = client.GetPolicy(ctx, &guardianv1beta1.GetPolicyRequest{
+			_, err = client.GetPolicy(cmd.Context(), &guardianv1beta1.GetPolicyRequest{
 				Id: policyID,
 			})
 			policyExists := true
@@ -384,7 +377,7 @@ func applyPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobr
 			}
 
 			if policyExists {
-				res, err := client.UpdatePolicy(ctx, &guardianv1beta1.UpdatePolicyRequest{
+				res, err := client.UpdatePolicy(cmd.Context(), &guardianv1beta1.UpdatePolicyRequest{
 					Id:     policyID,
 					Policy: policyProto,
 				})
@@ -395,7 +388,7 @@ func applyPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobr
 
 				fmt.Printf("Policy updated to version: %v\n", res.GetPolicy().GetVersion())
 			} else {
-				res, err := client.CreatePolicy(ctx, &guardianv1beta1.CreatePolicyRequest{
+				res, err := client.CreatePolicy(cmd.Context(), &guardianv1beta1.CreatePolicyRequest{
 					Policy: policyProto,
 				})
 				if err != nil {
@@ -416,7 +409,7 @@ func applyPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobr
 	return cmd
 }
 
-func planPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
+func planPolicyCmd(adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
 	var filePath string
 
 	cmd := &cobra.Command{
@@ -445,15 +438,14 @@ func planPolicyCmd(c *app.CLIConfig, adapter handlerv1beta1.ProtoAdapter) *cobra
 				return err
 			}
 
-			ctx := context.Background()
-			client, cancel, err := createClient(ctx, c.Host)
+			client, cancel, err := createClient(cmd)
 			if err != nil {
 				return err
 			}
 			defer cancel()
 
 			policyID := policyProto.GetId()
-			res, err := client.GetPolicy(ctx, &guardianv1beta1.GetPolicyRequest{
+			res, err := client.GetPolicy(cmd.Context(), &guardianv1beta1.GetPolicyRequest{
 				Id: policyID,
 			})
 			if err != nil {

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -49,6 +49,7 @@ func PolicyCmd(adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
 	cmd.AddCommand(planPolicyCmd(adapter))
 	cmd.AddCommand(applyPolicyCmd(adapter))
 	cmd.AddCommand(initPolicyCmd())
+	bindFlagsFromConfig(cmd)
 
 	return cmd
 }

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -42,6 +42,7 @@ func ProviderCmd(adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
 	cmd.AddCommand(planProviderCmd(adapter))
 	cmd.AddCommand(applyProviderCmd(adapter))
 	cmd.AddCommand(initProviderCmd())
+	bindFlagsFromConfig(cmd)
 
 	return cmd
 }

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -31,6 +31,7 @@ func ResourceCmd(adapter handlerv1beta1.ProtoAdapter) *cobra.Command {
 	cmd.AddCommand(viewResourceCmd(adapter))
 	cmd.AddCommand(setResourceCmd(adapter))
 	cmd.PersistentFlags().StringP("output", "o", "", "Print output with specified format (yaml,json,prettyjson)")
+	bindFlagsFromConfig(cmd)
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func New() *cobra.Command {
+func New(cfg *Config) *cobra.Command {
+	cliConfig = cfg
 	var cmd = &cobra.Command{
 		Use:   "guardian <command> <subcommand> [flags]",
 		Short: "Universal data access control",
@@ -38,30 +39,19 @@ func New() *cobra.Command {
 	}
 
 	protoAdapter := handlerv1beta1.NewAdapter()
-	coreCommands := []*cobra.Command{
-		ResourceCmd(protoAdapter),
-		ProviderCmd(protoAdapter),
-		PolicyCmd(protoAdapter),
-		appealsCommand(),
-	}
-	cmd.AddCommand(coreCommands...)
+	cmd.AddCommand(ResourceCmd(protoAdapter))
+	cmd.AddCommand(ProviderCmd(protoAdapter))
+	cmd.AddCommand(PolicyCmd(protoAdapter))
+	cmd.AddCommand(appealsCommand())
+	cmd.AddCommand(ServerCommand())
+	cmd.AddCommand(configCommand())
+	cmd.AddCommand(VersionCmd())
 
-	otherCommands := []*cobra.Command{
-		ServerCommand(),
-		configCommand(),
-		VersionCmd(),
-		cmdx.SetCompletionCmd("guardian"),
-		cmdx.SetHelpTopic("environment", envHelp),
-		cmdx.SetRefCmd(cmd),
-	}
-	for _, c := range otherCommands {
-		c.SetHelpFunc(func(c *cobra.Command, s []string) {
-			cmd.Flags().MarkHidden("host")
-			cmd.HelpFunc()(c, s)
-		})
-	}
-	cmd.AddCommand(otherCommands...)
-
+	// Help topics
 	cmdx.SetHelp(cmd)
+	cmd.AddCommand(cmdx.SetCompletionCmd("guardian"))
+	cmd.AddCommand(cmdx.SetHelpTopic("environment", envHelp))
+	cmd.AddCommand(cmdx.SetRefCmd(cmd))
+
 	return cmd
 }

--- a/main.go
+++ b/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/odpf/guardian/cmd"
-	"github.com/odpf/salt/config"
 )
 
 const (
@@ -17,10 +15,7 @@ const (
 
 func main() {
 	cliConfig, err := cmd.LoadConfig()
-	if err != nil && !errors.As(err, &config.ConfigFileNotFoundError{}) {
-		panic(err)
-	}
-	if cliConfig == nil {
+	if err != nil {
 		cliConfig = &cmd.Config{}
 	}
 

--- a/main.go
+++ b/main.go
@@ -16,8 +16,6 @@ const (
 )
 
 func main() {
-	root := cmd.New()
-
 	cliConfig, err := cmd.LoadConfig()
 	if err != nil && !errors.As(err, &config.ConfigFileNotFoundError{}) {
 		panic(err)
@@ -25,10 +23,8 @@ func main() {
 	if cliConfig == nil {
 		cliConfig = &cmd.Config{}
 	}
-	if err := cmd.BindFlagsFromConfig(root, cliConfig); err != nil {
-		panic(err)
-	}
 
+	root := cmd.New(cliConfig)
 	if cmd, err := root.ExecuteC(); err != nil {
 		printError(err)
 


### PR DESCRIPTION
closes: #120 

changes:
- added `host` flag for core commands
- load config from file first, if it's not available, read config fields from flags
- refactor: move `app.CLIConfig` struct to `cmd.Config`

any config stored in the file should be override-able via flag too. Currently, there is only `host`