### PR TITLE
Fix: Add intermediate certs for OpenIDM SSL connectivity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM alpine:3.13
 
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 
-# Add intermediate certs to connect to OpenIDM
-RUN curl --output /usr/local/share/ca-certificates/temp.crt http://crt.sectigo.com/SectigoRSADomainValidationSecure
-ServerCA.crt
+RUN curl --output /usr/local/share/ca-certificates/SectigoRSADomainValidationSecureServerCA.crt http://crt.sectigo.com/SectigoRSADomainValidationSecureServerCA.crt
 
 COPY guardian .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM alpine:3.13
 
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 
+# Add intermediate certs to connect to OpenIDM
+RUN curl --output /usr/local/share/ca-certificates/temp.crt http://crt.sectigo.com/SectigoRSADomainValidationSecure
+ServerCA.crt
+
 COPY guardian .
 
 EXPOSE 8080


### PR DESCRIPTION
This cert is needed for connectivity with OpenIDM