### PR TITLE
feat(cmd): add sub-command for running jobs

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -9,6 +9,12 @@ import (
 	"github.com/odpf/salt/config"
 )
 
+type Jobs struct {
+	FetchResourcesInterval             string `mapstructure:"fetch_resources_interval" default:"0 */2 * * *"`
+	RevokeExpiredAccessInterval        string `mapstructure:"revoke_expired_access_interval" default:"*/20 * * * *"`
+	ExpiringAccessNotificationInterval string `mapstructure:"expiring_access_notification_interval" default:"0 9 * * *"`
+}
+
 type Config struct {
 	Port                       int              `mapstructure:"port" default:"8080"`
 	EncryptionSecretKeyKey     string           `mapstructure:"encryption_secret_key"`

--- a/app/services.go
+++ b/app/services.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"github.com/go-playground/validator/v10"
+	"github.com/odpf/guardian/core/appeal"
+	"github.com/odpf/guardian/core/approval"
+	"github.com/odpf/guardian/core/policy"
+	"github.com/odpf/guardian/core/provider"
+	"github.com/odpf/guardian/core/resource"
+	"github.com/odpf/guardian/domain"
+	"github.com/odpf/guardian/plugins/identities"
+	"github.com/odpf/guardian/plugins/notifiers"
+	"github.com/odpf/guardian/plugins/providers"
+	"github.com/odpf/guardian/plugins/providers/bigquery"
+	"github.com/odpf/guardian/plugins/providers/gcloudiam"
+	"github.com/odpf/guardian/plugins/providers/grafana"
+	"github.com/odpf/guardian/plugins/providers/metabase"
+	"github.com/odpf/guardian/plugins/providers/tableau"
+	"github.com/odpf/guardian/store/postgres"
+	"github.com/odpf/salt/log"
+)
+
+type Services struct {
+	ResourceService *resource.Service
+	ProviderService *provider.Service
+	PolicyService   *policy.Service
+	ApprovalService *approval.Service
+	AppealService   *appeal.Service
+}
+
+type ServiceDeps struct {
+	Config *Config
+	// TODO: make items below as options
+	Logger    log.Logger
+	Validator *validator.Validate
+	Notifier  notifiers.Client
+	Crypto    domain.Crypto
+}
+
+func InitServices(deps ServiceDeps) (*Services, error) {
+	store, err := getStore(deps.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	providerRepository := postgres.NewProviderRepository(store.DB())
+	policyRepository := postgres.NewPolicyRepository(store.DB())
+	resourceRepository := postgres.NewResourceRepository(store.DB())
+	appealRepository := postgres.NewAppealRepository(store.DB())
+	approvalRepository := postgres.NewApprovalRepository(store.DB())
+
+	providerClients := []providers.Client{
+		bigquery.NewProvider(domain.ProviderTypeBigQuery, deps.Crypto),
+		metabase.NewProvider(domain.ProviderTypeMetabase, deps.Crypto),
+		grafana.NewProvider(domain.ProviderTypeGrafana, deps.Crypto),
+		tableau.NewProvider(domain.ProviderTypeTableau, deps.Crypto),
+		gcloudiam.NewProvider(domain.ProviderTypeGCloudIAM, deps.Crypto),
+	}
+
+	iamManager := identities.NewManager(deps.Crypto, deps.Validator)
+
+	resourceService := resource.NewService(resourceRepository)
+	providerService := provider.NewService(
+		deps.Logger,
+		deps.Validator,
+		providerRepository,
+		resourceService,
+		providerClients,
+	)
+	policyService := policy.NewService(
+		deps.Validator,
+		policyRepository,
+		resourceService,
+		providerService,
+		iamManager,
+	)
+	approvalService := approval.NewService(
+		approvalRepository,
+		policyService,
+	)
+	appealService := appeal.NewService(
+		appealRepository,
+		approvalService,
+		resourceService,
+		providerService,
+		policyService,
+		iamManager,
+		deps.Notifier,
+		deps.Logger,
+	)
+
+	return &Services{
+		resourceService,
+		providerService,
+		policyService,
+		approvalService,
+		appealService,
+	}, nil
+}

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -42,7 +42,7 @@ func runJobCmd() *cobra.Command {
 			$ guardian job run appeal_expiration_reminder
 			$ guardian job run appeal_expiration_revocation
 		`),
-		Args: cobra.OnlyValidArgs,
+		Args: cobra.ExactValidArgs(1),
 		ValidArgs: []string{
 			"fetch_resources",
 			"appeal_expiration_reminder",

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -13,12 +13,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func JobsCmd() *cobra.Command {
+func JobCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "jobs",
-		Short: "Manage jobs",
+		Use:     "job",
+		Aliases: []string{"jobs"},
+		Short:   "Manage jobs",
 		Example: heredoc.Doc(`
-			$ guardian jobs run fetch_resources
+			$ guardian job run fetch_resources
 		`),
 	}
 
@@ -37,7 +38,9 @@ func runJobCmd() *cobra.Command {
 		Use:   "run",
 		Short: "Fire a specific job",
 		Example: heredoc.Doc(`
-			$ guardian jobs run fetch_resources
+			$ guardian job run fetch_resources
+			$ guardian job run appeal_expiration_reminder
+			$ guardian job run appeal_expiration_revocation
 		`),
 		Args: cobra.OnlyValidArgs,
 		ValidArgs: []string{

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -90,11 +90,16 @@ func runJobCmd() *cobra.Command {
 				"appeal_expiration_revocation": handler.RevokeExpiredAppeals,
 			}
 
-			job := jobs[args[0]]
+			jobName := args[0]
+			job := jobs[jobName]
 			if job == nil {
-				return fmt.Errorf("invalid job name: %s", args[0])
+				return fmt.Errorf("invalid job name: %s", jobName)
 			}
-			return job()
+			if err := job(); err != nil {
+				return fmt.Errorf(`failed to run job "%s": %w`, jobName, err)
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/go-playground/validator/v10"
+	"github.com/odpf/guardian/app"
+	"github.com/odpf/guardian/internal/crypto"
+	"github.com/odpf/guardian/jobs"
+	"github.com/odpf/guardian/plugins/notifiers"
+	"github.com/odpf/salt/log"
+	"github.com/spf13/cobra"
+)
+
+func JobsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "jobs",
+		Short: "Manage jobs",
+		Example: heredoc.Doc(`
+			$ guardian jobs run fetch_resources
+		`),
+	}
+
+	cmd.AddCommand(
+		runJobCmd(),
+	)
+
+	cmd.PersistentFlags().StringP("config", "c", "./config.yaml", "Config file path")
+	cmd.MarkPersistentFlagFilename("config")
+
+	return cmd
+}
+
+func runJobCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Fire a specific job",
+		Example: heredoc.Doc(`
+			$ guardian jobs run fetch_resources
+		`),
+		Args: cobra.OnlyValidArgs,
+		ValidArgs: []string{
+			"fetch_resources",
+			"appeal_expiration_reminder",
+			"appeal_expiration_revocation",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile, err := cmd.Flags().GetString("config")
+			if err != nil {
+				return fmt.Errorf("getting config flag value: %w", err)
+			}
+			config, err := app.LoadConfig(configFile)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			logger := log.NewLogrus(log.LogrusWithLevel(config.LogLevel))
+			crypto := crypto.NewAES(config.EncryptionSecretKeyKey)
+			validator := validator.New()
+			notifier, err := notifiers.NewClient(&config.Notifier)
+			if err != nil {
+				return err
+			}
+
+			services, err := app.InitServices(app.ServiceDeps{
+				Config:    &config,
+				Logger:    logger,
+				Validator: validator,
+				Notifier:  notifier,
+				Crypto:    crypto,
+			})
+			if err != nil {
+				return fmt.Errorf("initializing services: %w", err)
+			}
+
+			handler := jobs.NewHandler(
+				logger,
+				services.AppealService,
+				services.ProviderService,
+				notifier,
+			)
+
+			jobs := map[string]func() error{
+				"fetch_resources":              handler.FetchResources,
+				"appeal_expiration_reminder":   handler.AppealExpirationReminder,
+				"appeal_expiration_revocation": handler.RevokeExpiredAppeals,
+			}
+
+			job := jobs[args[0]]
+			if job == nil {
+				return fmt.Errorf("invalid job name: %s", args[0])
+			}
+			return job()
+		},
+	}
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ func New(cfg *Config) *cobra.Command {
 	cmd.AddCommand(PolicyCmd(protoAdapter))
 	cmd.AddCommand(appealsCommand())
 	cmd.AddCommand(ServerCommand())
-	cmd.AddCommand(JobsCmd())
+	cmd.AddCommand(JobCmd())
 	cmd.AddCommand(configCommand())
 	cmd.AddCommand(VersionCmd())
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ func New(cfg *Config) *cobra.Command {
 	cmd.AddCommand(PolicyCmd(protoAdapter))
 	cmd.AddCommand(appealsCommand())
 	cmd.AddCommand(ServerCommand())
+	cmd.AddCommand(JobsCmd())
 	cmd.AddCommand(configCommand())
 	cmd.AddCommand(VersionCmd())
 

--- a/core/provider/service.go
+++ b/core/provider/service.go
@@ -21,7 +21,7 @@ type resourceService interface {
 
 // Service handling the business logics
 type Service struct {
-	logger             *log.Logrus
+	logger             log.Logger
 	validator          *validator.Validate
 	providerRepository store.ProviderRepository
 	resourceService    resourceService
@@ -31,7 +31,7 @@ type Service struct {
 
 // NewService returns service struct
 func NewService(
-	logger *log.Logrus,
+	logger log.Logger,
 	validator *validator.Validate,
 	pr store.ProviderRepository,
 	rs resourceService,

--- a/store/postgres/resource_repository_test.go
+++ b/store/postgres/resource_repository_test.go
@@ -251,6 +251,14 @@ func (s *ResourceRepositoryTestSuite) TestBulkUpsert() {
 			s.Equal(expectedIDs[i], r.ID)
 		}
 	})
+
+	s.Run("should return nil error if resources input is empty", func() {
+		var resources []*domain.Resource
+
+		err := s.repository.BulkUpsert(resources)
+
+		s.Nil(err)
+	})
 }
 
 func (s *ResourceRepositoryTestSuite) TestUpdate() {


### PR DESCRIPTION
closes #140 

usage: `guardian jobs run <job_name>`
example: `guardian jobs run fetch_resources`
valid job names: `fetch_resources`, `appeal_expiration_reminder`, `appeal_expiration_revocation`