### PR TITLE
fix(notifiers): cache slack id

### DIFF
--- a/plugins/notifiers/slack/client.go
+++ b/plugins/notifiers/slack/client.go
@@ -111,6 +111,7 @@ func (n *notifier) findSlackIDByEmail(email string) (string, error) {
 		return "", errors.New("user not found")
 	}
 
+	n.slackIDCache[email] = result.User.ID
 	return result.User.ID, nil
 }
 


### PR DESCRIPTION
At the moment, there is provision to cache slack ID instead of calling the slack api each time for notifications. But the id is not cached due to the missed line of code, which this PR aims to fix.