### PR TITLE
fix(jobs): use createdBy instead of accountID for appeal expiry reminder

### DIFF
--- a/jobs/appeal_expiration_reminder.go
+++ b/jobs/appeal_expiration_reminder.go
@@ -37,7 +37,7 @@ func (h *handler) AppealExpirationReminder(ctx context.Context) error {
 		var notifications []domain.Notification
 		for _, a := range appeals {
 			notifications = append(notifications, domain.Notification{
-				User: a.AccountID,
+				User: a.CreatedBy,
 				Message: domain.NotificationMessage{
 					Type: domain.NotificationTypeExpirationReminder,
 					Variables: map[string]interface{}{


### PR DESCRIPTION
fix #175 