### PR TITLE
fix(appeal): skip creation on appeal duplication error for additional appeals

### DIFF
--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -774,7 +774,7 @@ func (s *Service) handleAppealRequirements(ctx context.Context, a *domain.Appeal
 					if errors.Is(err, ErrAppealDuplicate) {
 						continue
 					}
-					return fmt.Errorf("creating additional appeals: %v", err)
+					return fmt.Errorf("creating additional appeals: %w", err)
 				}
 			}
 		}

--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -12,6 +12,7 @@ package appeal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -738,7 +739,6 @@ func (s *Service) fillApprovals(a *domain.Appeal, p *domain.Policy) error {
 }
 
 func (s *Service) handleAppealRequirements(ctx context.Context, a *domain.Appeal, p *domain.Policy) error {
-	additionalAppeals := []*domain.Appeal{}
 	if p.Requirements != nil && len(p.Requirements) > 0 {
 		for reqIndex, r := range p.Requirements {
 			isAppealMatchesRequirement, err := r.On.IsMatch(a)
@@ -770,13 +770,13 @@ func (s *Service) handleAppealRequirements(ctx context.Context, a *domain.Appeal
 					additionalAppeal.PolicyID = aa.Policy.ID
 					additionalAppeal.PolicyVersion = uint(aa.Policy.Version)
 				}
-				additionalAppeals = append(additionalAppeals, additionalAppeal)
+				if err := s.Create(ctx, []*domain.Appeal{additionalAppeal}); err != nil {
+					if errors.Is(err, ErrAppealDuplicate) {
+						continue
+					}
+					return fmt.Errorf("creating additional appeals: %v", err)
+				}
 			}
-		}
-	}
-	if len(additionalAppeals) > 0 {
-		if err := s.Create(ctx, additionalAppeals); err != nil {
-			return fmt.Errorf("creating additional appeals: %v", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
bug: extending an appeal that is linked to a policy with additional appeals was not working because guardian detected the existing additional appeals already exist. This fix will allow the appeal to be created (activated) even the additional appeals are still active by skipping the additional appeals creation.