### PR TITLE
fix(appeal): additional appeal policy override

### DIFF
--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -809,9 +809,11 @@ func (s *Service) CreateAccess(ctx context.Context, a *domain.Appeal) error {
 		policy = p
 	}
 
-	// TODO: don't handle appeal requirements if current appeal already an additional appeal
-	if err := s.handleAppealRequirements(ctx, a, policy); err != nil {
-		return fmt.Errorf("handling appeal requirements: %w", err)
+	isAdditionalAppealCreation, _ := ctx.Value(ContextKeyIsAdditionalAppealCreation{}).(bool)
+	if !isAdditionalAppealCreation {
+		if err := s.handleAppealRequirements(ctx, a, policy); err != nil {
+			return fmt.Errorf("handling appeal requirements: %w", err)
+		}
 	}
 
 	if err := s.providerService.GrantAccess(ctx, a); err != nil {

--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -36,6 +36,8 @@ const (
 
 var TimeNow = time.Now
 
+type ContextKeyIsAdditionalAppealCreation struct{}
+
 type repository interface {
 	BulkUpsert([]*domain.Appeal) error
 	Find(*domain.ListAppealsFilter) ([]*domain.Appeal, error)
@@ -141,6 +143,8 @@ func (s *Service) Find(ctx context.Context, filters *domain.ListAppealsFilter) (
 
 // Create record
 func (s *Service) Create(ctx context.Context, appeals []*domain.Appeal) error {
+	isAdditionalAppealCreation, _ := ctx.Value(ContextKeyIsAdditionalAppealCreation{}).(bool)
+
 	resourceIDs := []string{}
 	for _, a := range appeals {
 		resourceIDs = append(resourceIDs, a.ResourceID)
@@ -197,9 +201,15 @@ func (s *Service) Create(ctx context.Context, appeals []*domain.Appeal) error {
 			return fmt.Errorf("validating appeal based on provider: %w", err)
 		}
 
-		policy, err := getPolicy(appeal, provider, policies)
-		if err != nil {
-			return fmt.Errorf("retrieving policy: %w", err)
+		var policy *domain.Policy
+		if isAdditionalAppealCreation && appeal.PolicyID != "" && appeal.PolicyVersion != 0 {
+			policy = policies[appeal.PolicyID][appeal.PolicyVersion]
+		} else {
+			var err error
+			policy, err = getPolicy(appeal, provider, policies)
+			if err != nil {
+				return fmt.Errorf("retrieving policy: %w", err)
+			}
 		}
 
 		if err := s.addCreatorDetails(appeal, policy); err != nil {
@@ -776,6 +786,7 @@ func (s *Service) handleAppealRequirements(ctx context.Context, a *domain.Appeal
 					additionalAppeal.PolicyID = aa.Policy.ID
 					additionalAppeal.PolicyVersion = uint(aa.Policy.Version)
 				}
+				ctx = context.WithValue(ctx, ContextKeyIsAdditionalAppealCreation{}, true)
 				if err := s.Create(ctx, []*domain.Appeal{additionalAppeal}); err != nil {
 					if errors.Is(err, ErrAppealDuplicate) {
 						continue
@@ -798,6 +809,7 @@ func (s *Service) CreateAccess(ctx context.Context, a *domain.Appeal) error {
 		policy = p
 	}
 
+	// TODO: don't handle appeal requirements if current appeal already an additional appeal
 	if err := s.handleAppealRequirements(ctx, a, policy); err != nil {
 		return fmt.Errorf("handling appeal requirements: %w", err)
 	}


### PR DESCRIPTION
### bug:
policy example:
```yaml
...
requirements:
  on:
    resource_id: 123
  appeals:
    - resource:
         id: 456
       role: viewer
       policy:
         id: policy-x # overriding policy
         version: 99
```
the policy (policy-x@99) specified above won't get applied for the additional appeal creation for resource_id:456

this PR is for fixing that bug