### PR TITLE
fix: optimize list approvals query

### DIFF
--- a/internal/store/postgres/approval_repository.go
+++ b/internal/store/postgres/approval_repository.go
@@ -30,55 +30,41 @@ func (r *ApprovalRepository) ListApprovals(conditions *domain.ListApprovalsFilte
 		return nil, err
 	}
 
-	db := r.db
+	records := []*domain.Approval{}
+
+	db := r.db.Preload("Appeal.Resource")
+	db = db.Joins("Appeal")
+	db = db.Joins(`JOIN "approvers" ON "approvals"."id" = "approvers"."approval_id"`)
+
 	if conditions.CreatedBy != "" {
-		db = db.Where("email = ?", conditions.CreatedBy)
+		db = db.Where(`"approvers"."email" = ?`, conditions.CreatedBy)
+	}
+	if conditions.Statuses != nil {
+		db = db.Where(`"approvals"."status" IN ?`, conditions.Statuses)
+	}
+	if conditions.AccountID != "" {
+		db = db.Where(`"Appeal"."account_id" = ?`, conditions.AccountID)
+	}
+	db = db.Where(`"Appeal"."status" != ?`, domain.AppealStatusCanceled)
+
+	if conditions.OrderBy != nil {
+		db = addOrderByClause(db, conditions.OrderBy, addOrderByClauseOptions{
+			statusColumnName: `"approvals"."status"`,
+		})
 	}
 
-	var approverModels []*model.Approver
-	if err := db.Find(&approverModels).Error; err != nil {
+	var models []*model.Approval
+	if err := db.Find(&models).Error; err != nil {
 		return nil, err
 	}
 
-	records := []*domain.Approval{}
-
-	if len(approverModels) > 0 {
-		var approvalIDs []string
-		for _, a := range approverModels {
-			approvalIDs = append(approvalIDs, a.ApprovalID)
-		}
-
-		db = r.db.Preload("Appeal.Resource")
-		db = db.Joins("Appeal")
-		if conditions.Statuses != nil {
-			db = db.Where(`"approvals"."status" IN ?`, conditions.Statuses)
-		}
-		if conditions.AccountID != "" {
-			db = db.Where(`"Appeal"."account_id" = ?`, conditions.AccountID)
-		}
-		db = db.Where(`"Appeal"."status" != ?`, domain.AppealStatusCanceled)
-
-		if conditions.OrderBy != nil {
-			db = addOrderByClause(db, conditions.OrderBy, addOrderByClauseOptions{
-				statusColumnName: `"approvals"."status"`,
-			})
-		}
-
-		var models []*model.Approval
-		if err := db.
-			Find(&models, approvalIDs).
-			Error; err != nil {
+	for _, m := range models {
+		approval, err := m.ToDomain()
+		if err != nil {
 			return nil, err
 		}
 
-		for _, m := range models {
-			approval, err := m.ToDomain()
-			if err != nil {
-				return nil, err
-			}
-
-			records = append(records, approval)
-		}
+		records = append(records, approval)
 	}
 
 	return records, nil

--- a/internal/store/postgres/approval_repository_test.go
+++ b/internal/store/postgres/approval_repository_test.go
@@ -101,15 +101,15 @@ func (s *ApprovalRepositoryTestSuite) TestListApprovals() {
 		expectedUser := "user@example.com"
 		expectedAccountID := "account@example.com"
 		expectedStatuses := []string{"test-status-1", "test-status-2"}
-		expectedApprovers := []*domain.Approver{
-			{
-				ID:         uuid.New().String(),
-				ApprovalID: approvalID,
-				Email:      expectedUser,
-				CreatedAt:  timeNow,
-				UpdatedAt:  timeNow,
-			},
-		}
+		//expectedApprovers := []*domain.Approver{
+		//	{
+		//		ID:         uuid.New().String(),
+		//		ApprovalID: approvalID,
+		//		Email:      expectedUser,
+		//		CreatedAt:  timeNow,
+		//		UpdatedAt:  timeNow,
+		//	},
+		//}
 		expectedApprovals := []*domain.Approval{
 			{
 				ID:            approvalID,
@@ -140,15 +140,7 @@ func (s *ApprovalRepositoryTestSuite) TestListApprovals() {
 			},
 		}
 
-		expectedListApproversQuery := regexp.QuoteMeta(`SELECT * FROM "approvers" WHERE email = $1 AND "approvers"."deleted_at" IS NULL`)
-		expectedApproverRows := sqlmock.NewRows(s.approverColumnNames)
-		for _, a := range expectedApprovers {
-			expectedApproverRows.AddRow(a.ID, a.Email, a.AppealID, a.ApprovalID, a.CreatedAt, a.UpdatedAt)
-		}
-		s.dbmock.ExpectQuery(expectedListApproversQuery).
-			WithArgs(expectedUser).
-			WillReturnRows(expectedApproverRows)
-		expectedListApprovalsQuery := regexp.QuoteMeta(`SELECT "approvals"."id","approvals"."name","approvals"."index","approvals"."appeal_id","approvals"."status","approvals"."actor","approvals"."reason","approvals"."policy_id","approvals"."policy_version","approvals"."created_at","approvals"."updated_at","approvals"."deleted_at","Appeal"."id" AS "Appeal__id","Appeal"."resource_id" AS "Appeal__resource_id","Appeal"."policy_id" AS "Appeal__policy_id","Appeal"."policy_version" AS "Appeal__policy_version","Appeal"."status" AS "Appeal__status","Appeal"."account_id" AS "Appeal__account_id","Appeal"."account_type" AS "Appeal__account_type","Appeal"."created_by" AS "Appeal__created_by","Appeal"."creator" AS "Appeal__creator","Appeal"."role" AS "Appeal__role","Appeal"."permissions" AS "Appeal__permissions","Appeal"."options" AS "Appeal__options","Appeal"."labels" AS "Appeal__labels","Appeal"."details" AS "Appeal__details","Appeal"."revoked_by" AS "Appeal__revoked_by","Appeal"."revoked_at" AS "Appeal__revoked_at","Appeal"."revoke_reason" AS "Appeal__revoke_reason","Appeal"."created_at" AS "Appeal__created_at","Appeal"."updated_at" AS "Appeal__updated_at","Appeal"."deleted_at" AS "Appeal__deleted_at" FROM "approvals" LEFT JOIN "appeals" "Appeal" ON "approvals"."appeal_id" = "Appeal"."id" WHERE "approvals"."status" IN ($1,$2) AND "Appeal"."account_id" = $3 AND "Appeal"."status" != $4 AND "approvals"."id" = $5 AND "approvals"."deleted_at" IS NULL ORDER BY ARRAY_POSITION(ARRAY[$6,$7,$8,$9,$10], "approvals"."status"), "updated_at" desc, "created_at"`)
+		expectedListApprovalsQuery := regexp.QuoteMeta(`SELECT "approvals"."id","approvals"."name","approvals"."index","approvals"."appeal_id","approvals"."status","approvals"."actor","approvals"."reason","approvals"."policy_id","approvals"."policy_version","approvals"."created_at","approvals"."updated_at","approvals"."deleted_at","Appeal"."id" AS "Appeal__id","Appeal"."resource_id" AS "Appeal__resource_id","Appeal"."policy_id" AS "Appeal__policy_id","Appeal"."policy_version" AS "Appeal__policy_version","Appeal"."status" AS "Appeal__status","Appeal"."account_id" AS "Appeal__account_id","Appeal"."account_type" AS "Appeal__account_type","Appeal"."created_by" AS "Appeal__created_by","Appeal"."creator" AS "Appeal__creator","Appeal"."role" AS "Appeal__role","Appeal"."permissions" AS "Appeal__permissions","Appeal"."options" AS "Appeal__options","Appeal"."labels" AS "Appeal__labels","Appeal"."details" AS "Appeal__details","Appeal"."revoked_by" AS "Appeal__revoked_by","Appeal"."revoked_at" AS "Appeal__revoked_at","Appeal"."revoke_reason" AS "Appeal__revoke_reason","Appeal"."created_at" AS "Appeal__created_at","Appeal"."updated_at" AS "Appeal__updated_at","Appeal"."deleted_at" AS "Appeal__deleted_at" FROM "approvals" LEFT JOIN "appeals" "Appeal" ON "approvals"."appeal_id" = "Appeal"."id" JOIN "approvers" ON "approvals"."id" = "approvers"."approval_id" WHERE "approvers"."email" = $1 AND "approvals"."status" IN ($2,$3) AND "Appeal"."account_id" = $4 AND "Appeal"."status" != $5 AND "approvals"."deleted_at" IS NULL ORDER BY ARRAY_POSITION(ARRAY[$6,$7,$8,$9,$10], "approvals"."status"), "updated_at" desc, "created_at"`)
 		approvalColumnNames := s.approvalColumnNames
 		for _, c := range s.appealColumnNames {
 			approvalColumnNames = append(approvalColumnNames, fmt.Sprintf("Appeal__%s", c))
@@ -164,7 +156,7 @@ func (s *ApprovalRepositoryTestSuite) TestListApprovals() {
 			)
 		}
 		s.dbmock.ExpectQuery(expectedListApprovalsQuery).
-			WithArgs(expectedStatuses[0], expectedStatuses[1], expectedAccountID, domain.AppealStatusCanceled, approvalID,
+			WithArgs(expectedUser, expectedStatuses[0], expectedStatuses[1], expectedAccountID, domain.AppealStatusCanceled,
 				domain.AppealStatusPending,
 				domain.AppealStatusActive,
 				domain.AppealStatusRejected,

--- a/internal/store/postgres/approval_repository_test.go
+++ b/internal/store/postgres/approval_repository_test.go
@@ -101,15 +101,6 @@ func (s *ApprovalRepositoryTestSuite) TestListApprovals() {
 		expectedUser := "user@example.com"
 		expectedAccountID := "account@example.com"
 		expectedStatuses := []string{"test-status-1", "test-status-2"}
-		//expectedApprovers := []*domain.Approver{
-		//	{
-		//		ID:         uuid.New().String(),
-		//		ApprovalID: approvalID,
-		//		Email:      expectedUser,
-		//		CreatedAt:  timeNow,
-		//		UpdatedAt:  timeNow,
-		//	},
-		//}
 		expectedApprovals := []*domain.Approval{
 			{
 				ID:            approvalID,

--- a/plugins/providers/bigquery/config_test.go
+++ b/plugins/providers/bigquery/config_test.go
@@ -56,7 +56,6 @@ func TestCredentials(t *testing.T) {
 	})
 
 	t.Run("decrypt", func(t *testing.T) {
-
 		t.Run("should return error if creds is nil", func(t *testing.T) {
 			var creds *bigquery.Credentials
 

--- a/plugins/providers/bigquery/provider_test.go
+++ b/plugins/providers/bigquery/provider_test.go
@@ -25,7 +25,6 @@ func TestGetType(t *testing.T) {
 }
 
 func TestCreateConfig(t *testing.T) {
-
 	t.Run("should return error if error in credentials are invalid/mandatory fields are missing", func(t *testing.T) {
 		crypto := new(mocks.Crypto)
 		client := new(mocks.BigQueryClient)
@@ -172,7 +171,7 @@ func TestCreateConfig(t *testing.T) {
 						{
 							ID:          "VIEWER",
 							Name:        "VIEWER",
-							Permissions: []interface{}{"invalid permissions for resouce type"},
+							Permissions: []interface{}{"invalid permissions for resource type"},
 						},
 					},
 				},
@@ -347,8 +346,7 @@ func TestGetResources(t *testing.T) {
 }
 
 func TestGrantAccess(t *testing.T) {
-
-	t.Run("should return error if Provider Config or Appeal doesn't have required paramters", func(t *testing.T) {
+	t.Run("should return error if Provider Config or Appeal doesn't have required parameters", func(t *testing.T) {
 		testCases := []struct {
 			name           string
 			providerConfig *domain.ProviderConfig
@@ -416,7 +414,6 @@ func TestGrantAccess(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-
 			p := initProvider()
 			pc := tc.providerConfig
 			a := tc.appeal
@@ -615,8 +612,7 @@ func TestGrantAccess(t *testing.T) {
 }
 
 func TestRevokeAccess(t *testing.T) {
-
-	t.Run("should return error if Provider Config or Appeal doesn't have required paramters", func(t *testing.T) {
+	t.Run("should return error if Provider Config or Appeal doesn't have required parameters", func(t *testing.T) {
 		testCases := []struct {
 			providerConfig *domain.ProviderConfig
 			appeal         *domain.Appeal
@@ -683,7 +679,6 @@ func TestRevokeAccess(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-
 			p := initProvider()
 			pc := tc.providerConfig
 			a := tc.appeal

--- a/plugins/providers/bigquery/resource_test.go
+++ b/plugins/providers/bigquery/resource_test.go
@@ -67,7 +67,6 @@ func TestDataSet(t *testing.T) {
 			assert.Nil(t, actualError)
 			assert.Equal(t, expectedDataset, d)
 		})
-
 	})
 }
 
@@ -144,6 +143,5 @@ func TestTable(t *testing.T) {
 			assert.Nil(t, actualError)
 			assert.Equal(t, expectedTable, d)
 		})
-
 	})
 }

--- a/plugins/providers/gcloudiam/config_test.go
+++ b/plugins/providers/gcloudiam/config_test.go
@@ -55,7 +55,6 @@ func TestCredentials(t *testing.T) {
 	})
 
 	t.Run("decrypt", func(t *testing.T) {
-
 		t.Run("should return error if creds is nil", func(t *testing.T) {
 			var creds *gcloudiam.Credentials
 
@@ -94,4 +93,3 @@ func TestCredentials(t *testing.T) {
 		})
 	})
 }
-

--- a/plugins/providers/gcloudiam/provider_test.go
+++ b/plugins/providers/gcloudiam/provider_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCreateConfig(t *testing.T) {
-
 	t.Run("should return error if error in credentials are invalid/mandatory fields are missing", func(t *testing.T) {
 		providerURN := "test-URN"
 		crypto := new(mocks.Crypto)
@@ -193,7 +192,6 @@ func TestGetType(t *testing.T) {
 }
 
 func TestGetResources(t *testing.T) {
-
 	t.Run("should error when credentials are invalid", func(t *testing.T) {
 		crypto := new(mocks.Crypto)
 		p := gcloudiam.NewProvider("", crypto)
@@ -495,7 +493,6 @@ func TestRevokeAccess(t *testing.T) {
 }
 
 func TestGetRoles(t *testing.T) {
-
 	t.Run("should return error if resource type is not project or organisation", func(t *testing.T) {
 		expectedError := gcloudiam.ErrInvalidResourceType
 		providerURN := "test-provider-urn"
@@ -564,7 +561,6 @@ func TestGetRoles(t *testing.T) {
 		assert.Nil(t, actualError)
 		client.AssertExpectations(t)
 	})
-
 }
 
 func TestGetAccountTypes(t *testing.T) {

--- a/plugins/providers/grafana/client_test.go
+++ b/plugins/providers/grafana/client_test.go
@@ -107,7 +107,6 @@ func (s *ClientTestSuite) setup() {
 }
 
 func (s *ClientTestSuite) TestGetFolders() {
-
 	s.Run("should get folders and nil error on success", func() {
 		s.setup()
 
@@ -156,7 +155,6 @@ func (s *ClientTestSuite) TestGetFolders() {
 }
 
 func (s *ClientTestSuite) TestGetDashboards() {
-
 	s.Run("should get folders and nil error on success", func() {
 		s.setup()
 
@@ -233,7 +231,6 @@ func (s *ClientTestSuite) getTestRequest(method, path string, body interface{}) 
 }
 
 func (s *ClientTestSuite) TestGrantDashboardAccess() {
-
 	s.Run("should return error if user not found", func() {
 		s.setup()
 
@@ -389,7 +386,6 @@ func (s *ClientTestSuite) TestGrantDashboardAccess() {
 }
 
 func (s *ClientTestSuite) TestRevokeDashboardAccess() {
-
 	s.Run("should return error if user not found", func() {
 		s.setup()
 

--- a/plugins/providers/grafana/provider_test.go
+++ b/plugins/providers/grafana/provider_test.go
@@ -24,7 +24,6 @@ func TestGetType(t *testing.T) {
 }
 
 func TestCreateConfig(t *testing.T) {
-
 	t.Run("should return error if there credentials are invalid", func(t *testing.T) {
 		providerURN := "test-provider-urn"
 		crypto := new(mocks.Crypto)
@@ -118,7 +117,6 @@ func TestCreateConfig(t *testing.T) {
 	})
 
 	t.Run("should not return error if parse and valid of Credentials are correct", func(t *testing.T) {
-
 		providerURN := "test-provider-urn"
 		crypto := new(mocks.Crypto)
 		client := new(mocks.GrafanaClient)
@@ -669,7 +667,6 @@ func TestRevokeAccess(t *testing.T) {
 
 			assert.EqualError(t, actualError, expectedError.Error())
 		})
-
 	})
 
 	t.Run("should return nil error if revoking access is successful", func(t *testing.T) {
@@ -725,7 +722,6 @@ func TestRevokeAccess(t *testing.T) {
 		assert.Nil(t, actualError)
 		client.AssertExpectations(t)
 	})
-
 }
 
 func TestGetRoles(t *testing.T) {

--- a/plugins/providers/metabase/client_test.go
+++ b/plugins/providers/metabase/client_test.go
@@ -149,7 +149,6 @@ func (s *ClientTestSuite) TestGetCollections() {
 }
 
 func (s *ClientTestSuite) TestGetDatabases() {
-
 	s.Run("should return error bad request, status code 400", func() {
 		s.setup()
 
@@ -235,7 +234,6 @@ func (s *ClientTestSuite) TestGetDatabases() {
 		s.Nil(err1)
 		s.Equal(expectedDatabases, databases)
 		s.mockHttpClient.AssertExpectations(s.T())
-
 	})
 }
 
@@ -304,7 +302,6 @@ func (s *ClientTestSuite) TestGetGroups() {
 		s.Equal(expectedDatabaseGroupResponse, actualDatabaseGroupResponse)
 		s.mockHttpClient.AssertExpectations(s.T())
 	})
-
 }
 
 func (s *ClientTestSuite) TestGrantDatabaseAccess() {
@@ -360,7 +357,6 @@ func (s *ClientTestSuite) TestGrantDatabaseAccess() {
 }
 
 func (s *ClientTestSuite) TestGrantCollectionAccess() {
-
 	s.Run("should grant access to collection and nil error on success", func() {
 		s.setup()
 
@@ -435,7 +431,6 @@ func (s *ClientTestSuite) TestGrantCollectionAccess() {
 }
 
 func (s *ClientTestSuite) TestRevokeCollectionAccess() {
-
 	s.Run("should grant access to collection and nil error on success", func() {
 		s.setup()
 
@@ -475,7 +470,6 @@ func (s *ClientTestSuite) TestRevokeCollectionAccess() {
 }
 
 func (s *ClientTestSuite) TestGrantGroupAccesss() {
-
 	s.Run("should return nil if user is already part of the group", func() {
 		s.setup()
 
@@ -493,7 +487,6 @@ func (s *ClientTestSuite) TestGrantGroupAccesss() {
 
 		s.Nil(actualError)
 		s.mockHttpClient.AssertExpectations(s.T())
-
 	})
 
 	s.Run("should add member to group and nil error on success", func() {

--- a/plugins/providers/metabase/provider_test.go
+++ b/plugins/providers/metabase/provider_test.go
@@ -28,7 +28,6 @@ func TestGetType(t *testing.T) {
 }
 
 func TestCreateConfig(t *testing.T) {
-
 	t.Run("should return error if there credentials are invalid", func(t *testing.T) {
 		providerURN := "test-provider-urn"
 		crypto := new(mocks.Crypto)
@@ -124,7 +123,6 @@ func TestCreateConfig(t *testing.T) {
 	})
 
 	t.Run("should not return error if parse and valid of Credentials are correct", func(t *testing.T) {
-
 		providerURN := "test-provider-urn"
 		crypto := new(mocks.Crypto)
 		client := new(mocks.MetabaseClient)
@@ -772,7 +770,6 @@ func TestGrantAccess(t *testing.T) {
 	})
 
 	t.Run("given Group resource", func(t *testing.T) {
-
 		t.Run("should return error if there is an error in granting group access", func(t *testing.T) {
 			providerURN := "test-provider-urn"
 			expectedError := errors.New("client error")
@@ -1004,7 +1001,6 @@ func TestGrantAccess(t *testing.T) {
 			assert.Nil(t, actualError)
 			client.AssertExpectations(t)
 		})
-
 	})
 }
 
@@ -1322,7 +1318,6 @@ func TestRevokeAccess(t *testing.T) {
 	})
 
 	t.Run("given Group resource", func(t *testing.T) {
-
 		t.Run("should return error if there is an error in revoking group access", func(t *testing.T) {
 			providerURN := "test-provider-urn"
 			expectedError := errors.New("client error")
@@ -1476,7 +1471,6 @@ func TestRevokeAccess(t *testing.T) {
 			assert.Nil(t, actualError)
 			client.AssertExpectations(t)
 		})
-
 	})
 }
 
@@ -1523,7 +1517,6 @@ func TestGetRoles(t *testing.T) {
 
 		assert.Nil(t, actualRoles)
 		assert.ErrorIs(t, actualError, provider.ErrInvalidResourceType)
-
 	})
 
 	t.Run("should return roles specified in the provider config", func(t *testing.T) {

--- a/plugins/providers/noop/provider.go
+++ b/plugins/providers/noop/provider.go
@@ -38,7 +38,6 @@ func (p *Provider) GetType() string {
 }
 
 func (p *Provider) CreateConfig(cfg *domain.ProviderConfig) error {
-
 	if cfg.Type != domain.ProviderTypeNoOp {
 		return ErrInvalidProviderType
 	}

--- a/plugins/providers/tableau/client_test.go
+++ b/plugins/providers/tableau/client_test.go
@@ -128,7 +128,6 @@ func (s *ClientTestSuite) setup() {
 }
 
 func (s *ClientTestSuite) TestGetWorkbooks() {
-
 	s.Run("should return error if status code is 403, user forbidden to get workbooks", func() {
 		s.setup()
 
@@ -193,7 +192,6 @@ func (s *ClientTestSuite) getTestRequest(method, path string, body interface{}) 
 }
 
 func (s *ClientTestSuite) TestGetFlows() {
-
 	s.Run("should get error if user is forbidden, Status Code 403", func() {
 		s.setup()
 
@@ -278,7 +276,6 @@ func (s *ClientTestSuite) TestGetFlows() {
 }
 
 func (s *ClientTestSuite) TestGetDataSources() {
-
 	s.Run("should return error if status code is 403, user forbidden to get workbooks", func() {
 		s.setup()
 
@@ -324,7 +321,6 @@ func (s *ClientTestSuite) TestGetDataSources() {
 }
 
 func (s *ClientTestSuite) TestGetViews() {
-
 	s.Run("should return error if status code is 403, user forbidden to get resource", func() {
 		s.setup()
 
@@ -419,7 +415,6 @@ func (s *ClientTestSuite) TestGetMetrics() {
 }
 
 func (s *ClientTestSuite) TestUpdateSiteRole() {
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -470,7 +465,6 @@ func (s *ClientTestSuite) TestUpdateSiteRole() {
 }
 
 func (s *ClientTestSuite) TestGrantWorkbookAccess() { //the body have to be updated later after fix getTestRequest
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -526,7 +520,6 @@ func (s *ClientTestSuite) TestGrantWorkbookAccess() { //the body have to be upda
 }
 
 func (s *ClientTestSuite) TestGrantFlowAccess() { //the body have to be updated later after fix getTestRequest
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -582,7 +575,6 @@ func (s *ClientTestSuite) TestGrantFlowAccess() { //the body have to be updated 
 }
 
 func (s *ClientTestSuite) TestGrantMetricAccess() { //the body have to be updated later after fix getTestRequest
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -608,7 +600,6 @@ func (s *ClientTestSuite) TestGrantMetricAccess() { //the body have to be update
 		s.Equal(expectedError, actualError)
 	})
 	s.Run("should grant access to metric and return no error on success", func() {
-
 		s.setup()
 
 		userEmail := "test-email@gojek.com"
@@ -638,7 +629,6 @@ func (s *ClientTestSuite) TestGrantMetricAccess() { //the body have to be update
 }
 
 func (s *ClientTestSuite) TestGrantDataSourceAccess() { //the body have to be updated later after fix getTestRequest
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -664,7 +654,6 @@ func (s *ClientTestSuite) TestGrantDataSourceAccess() { //the body have to be up
 		s.Equal(expectedError, actualError)
 	})
 	s.Run("should grant access to datasource and return nil error on success", func() {
-
 		s.setup()
 
 		userEmail := "test-email@gojek.com"
@@ -695,7 +684,6 @@ func (s *ClientTestSuite) TestGrantDataSourceAccess() { //the body have to be up
 }
 
 func (s *ClientTestSuite) TestGrantViewAccess() { //the body have to be updated later after fix getTestRequest
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -722,7 +710,6 @@ func (s *ClientTestSuite) TestGrantViewAccess() { //the body have to be updated 
 	})
 
 	s.Run("should grant access to view and return nil error on success", func() {
-
 		s.setup()
 
 		userEmail := "test-email@gojek.com"
@@ -753,7 +740,6 @@ func (s *ClientTestSuite) TestGrantViewAccess() { //the body have to be updated 
 }
 
 func (s *ClientTestSuite) TestRevokeWorkbookAccess() {
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -779,7 +765,6 @@ func (s *ClientTestSuite) TestRevokeWorkbookAccess() {
 		s.Equal(expectedError, actualError)
 	})
 	s.Run("should revoke access to workbook and return no error on success", func() {
-
 		s.setup()
 
 		userEmail := "test-email@gojek.com"
@@ -817,7 +802,6 @@ func (s *ClientTestSuite) TestRevokeWorkbookAccess() {
 }
 
 func (s *ClientTestSuite) TestRevokeFlowAccess() {
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -844,7 +828,6 @@ func (s *ClientTestSuite) TestRevokeFlowAccess() {
 	})
 
 	s.Run("should revoke access to flow and return nil error on success", func() {
-
 		s.setup()
 
 		userEmail := "test-email@gojek.com"
@@ -882,7 +865,6 @@ func (s *ClientTestSuite) TestRevokeFlowAccess() {
 }
 
 func (s *ClientTestSuite) TestRevokeMetricAccess() {
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -908,7 +890,6 @@ func (s *ClientTestSuite) TestRevokeMetricAccess() {
 		s.Equal(expectedError, actualError)
 	})
 	s.Run("should revoke access to metric and return nil error on success", func() {
-
 		s.setup()
 
 		userEmail := "test-email@gojek.com"
@@ -946,7 +927,6 @@ func (s *ClientTestSuite) TestRevokeMetricAccess() {
 }
 
 func (s *ClientTestSuite) TestRevokeDataSourceAccess() {
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -972,7 +952,6 @@ func (s *ClientTestSuite) TestRevokeDataSourceAccess() {
 		s.Equal(expectedError, actualError)
 	})
 	s.Run("should revoke access to datasource and return nil error on success", func() {
-
 		s.setup()
 
 		userEmail := "test-email@gojek.com"
@@ -1010,7 +989,6 @@ func (s *ClientTestSuite) TestRevokeDataSourceAccess() {
 }
 
 func (s *ClientTestSuite) TestRevokeViewAccess() {
-
 	s.Run("should return error if error in getting the user", func() {
 		s.setup()
 
@@ -1036,7 +1014,6 @@ func (s *ClientTestSuite) TestRevokeViewAccess() {
 		s.Equal(expectedError, actualError)
 	})
 	s.Run("should revoke access to view and return nil error on success", func() {
-
 		s.setup()
 
 		userEmail := "test-email@gojek.com"

--- a/plugins/providers/tableau/provider_test.go
+++ b/plugins/providers/tableau/provider_test.go
@@ -24,7 +24,6 @@ func TestGetType(t *testing.T) {
 }
 
 func TestCreateConfig(t *testing.T) {
-
 	t.Run("should return error if there credentials are invalid", func(t *testing.T) {
 		providerURN := "test-provider-urn"
 		crypto := new(mocks.Crypto)
@@ -121,7 +120,6 @@ func TestCreateConfig(t *testing.T) {
 	})
 
 	t.Run("should not return error if parse and valid of Credentials are correct", func(t *testing.T) {
-
 		providerURN := "test-provider-urn"
 		crypto := new(mocks.Crypto)
 		client := new(mocks.TableauClient)
@@ -184,7 +182,7 @@ func TestCreateConfig(t *testing.T) {
 							Type: tableau.ResourceTypeFlow,
 							Roles: []*domain.Role{
 								{
-									ID:   "change-hierachy",
+									ID:   "change-hierarchy",
 									Name: "test-name",
 									Permissions: []interface{}{
 										map[string]interface{}{


### PR DESCRIPTION
* Instead of fetching approvers first and using a `in` query to fetch approvals, join approvers with approvals table to remove the `in` clause

closes #231 