### PR TITLE
feat(provider)!: update provider with the latest value

### DIFF
--- a/core/provider/service.go
+++ b/core/provider/service.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/imdario/mergo"
 	"github.com/odpf/guardian/domain"
 	"github.com/odpf/guardian/plugins/providers"
 	"github.com/odpf/guardian/utils"
@@ -164,22 +163,6 @@ func (s *Service) GetOne(ctx context.Context, pType, urn string) (*domain.Provid
 
 // Update updates the non-zero value(s) only
 func (s *Service) Update(ctx context.Context, p *domain.Provider) error {
-	var currentProvider *domain.Provider
-	var err error
-
-	if len(p.ID) > 0 {
-		currentProvider, err = s.GetByID(ctx, p.ID)
-	} else {
-		currentProvider, err = s.GetOne(ctx, p.Type, p.URN)
-	}
-	if err != nil {
-		return err
-	}
-
-	if err := mergo.Merge(p, currentProvider); err != nil {
-		return err
-	}
-
 	c := s.getClient(p.Type)
 	if c == nil {
 		return ErrInvalidProviderType


### PR DESCRIPTION
Closes: #234 

Changes:
* Update provider record with the latest changes always without merging with the existing record
* Fix test case

BREAKING CHANGE: Current provider API works in a patch way although with issues. This change makes sure the provider takes in the latest value only without any merging with the existing value.