### PR TITLE
fix: use created_at, updated_at from appeals otherwise grants table loses the temporal order of access

### DIFF
--- a/internal/store/postgres/migrations/000007_create_grants_table.up.sql
+++ b/internal/store/postgres/migrations/000007_create_grants_table.up.sql
@@ -55,8 +55,8 @@ SELECT
   "revoked_at",
   "revoke_reason",
   "created_by",
-  NOW() AS "created_at",
-  NOW() AS "updated_at"
+  "created_at",
+  "updated_at"
 FROM
   "appeals"
 WHERE


### PR DESCRIPTION
fix: use created_at, updated_at from appeals otherwise grants table loses the temporal order of access