### PR TITLE
fix(grant): fix is_permanent filter condition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ravisuhag @rahmatrhd @AkarshSatija
+* @ravisuhag @rahmatrhd @AkarshSatija @mabdh

--- a/internal/store/postgres/grant_repository.go
+++ b/internal/store/postgres/grant_repository.go
@@ -50,7 +50,7 @@ func (r *GrantRepository) List(ctx context.Context, filter domain.ListGrantsFilt
 	if filter.CreatedBy != "" {
 		db = db.Where(`"grants"."created_by" = ?`, filter.CreatedBy)
 	}
-	if filter.IsPermanent != nil && *filter.IsPermanent {
+	if filter.IsPermanent != nil {
 		db = db.Where(`"grants"."is_permanent" = ?`, *filter.IsPermanent)
 	}
 	if filter.OrderBy != nil {


### PR DESCRIPTION
fixes an issue from recently merged PR #302: 
- list grants with filter `is_permanent=false` is not working because it's not passed in the repository
