### PR TITLE
fix: gcloud client tracing

### DIFF
--- a/plugins/providers/bigquery/client.go
+++ b/plugins/providers/bigquery/client.go
@@ -8,7 +8,6 @@ import (
 
 	bq "cloud.google.com/go/bigquery"
 	"github.com/odpf/guardian/domain"
-	"github.com/odpf/guardian/pkg/tracing"
 	bqApi "google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/iterator"
@@ -24,11 +23,7 @@ type bigQueryClient struct {
 
 func newBigQueryClient(projectID string, credentialsJSON []byte) (*bigQueryClient, error) {
 	ctx := context.Background()
-	clientOpts := []option.ClientOption{
-		option.WithCredentialsJSON(credentialsJSON),
-		option.WithHTTPClient(tracing.NewHttpClient("BigQueryHttpClient")),
-	}
-	client, err := bq.NewClient(ctx, projectID, clientOpts...)
+	client, err := bq.NewClient(ctx, projectID, option.WithCredentialsJSON(credentialsJSON))
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/providers/gcloudiam/client.go
+++ b/plugins/providers/gcloudiam/client.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/odpf/guardian/domain"
-	"github.com/odpf/guardian/pkg/tracing"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
@@ -25,11 +24,7 @@ type iamClient struct {
 
 func newIamClient(credentialsJSON []byte, resourceName string) (*iamClient, error) {
 	ctx := context.Background()
-	opts := []option.ClientOption{
-		option.WithCredentialsJSON(credentialsJSON),
-		option.WithHTTPClient(tracing.NewHttpClient("GCloudIAMHttpClient")),
-	}
-	cloudResourceManagerService, err := cloudresourcemanager.NewService(ctx, opts...)
+	cloudResourceManagerService, err := cloudresourcemanager.NewService(ctx, option.WithCredentialsJSON(credentialsJSON))
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/providers/gcs/client.go
+++ b/plugins/providers/gcs/client.go
@@ -6,7 +6,6 @@ import (
 
 	"cloud.google.com/go/iam"
 	"cloud.google.com/go/storage"
-	"github.com/odpf/guardian/pkg/tracing"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -24,11 +23,7 @@ type gcsClient struct {
 }
 
 func newGCSClient(projectID string, credentialsJSON []byte) (*gcsClient, error) {
-	opts := []option.ClientOption{
-		option.WithCredentialsJSON(credentialsJSON),
-		option.WithHTTPClient(tracing.NewHttpClient("GcsHttpClient")),
-	}
-	client, err := storage.NewClient(context.TODO(), opts...)
+	client, err := storage.NewClient(context.TODO(), option.WithCredentialsJSON(credentialsJSON))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix https://github.com/odpf/guardian/issues/345

If we use WithHTTPClient(), then the BigQuery client will be created without applying the WithToken() option. This means that Oauth won't be set up properly.