### PR TITLE
fix(grant): fix bug when grouping imported access

### DIFF
--- a/core/grant/service.go
+++ b/core/grant/service.go
@@ -432,14 +432,14 @@ func reduceGrantsByProviderRole(rc *domain.ResourceConfig, grants []*domain.Gran
 	}
 	sort.Strings(allGrantPermissions)
 
-	for roleID, permissionsByRole := range rolePermissionsMap {
-		if containing, headIndex := utils.SubsliceExists(allGrantPermissions, permissionsByRole); containing {
-			sampleGrant := grantsGroupedByPermission[allGrantPermissions[headIndex]]
+	for roleID, rolePermissions := range rolePermissionsMap {
+		if containing, headIndex := utils.SubsliceExists(allGrantPermissions, rolePermissions); containing {
+			sampleGrant := grantsGroupedByPermission[rolePermissions[0]]
 			sampleGrant.Role = roleID
-			sampleGrant.Permissions = permissionsByRole
+			sampleGrant.Permissions = rolePermissions
 			reducedGrants = append(reducedGrants, sampleGrant)
 
-			for _, p := range allGrantPermissions {
+			for _, p := range rolePermissions {
 				// delete combined grants
 				delete(grantsGroupedByPermission, p)
 			}

--- a/core/grant/service.go
+++ b/core/grant/service.go
@@ -451,7 +451,6 @@ func reduceGrantsByProviderRole(rc *domain.ResourceConfig, grants []*domain.Gran
 	if len(grantsGroupedByPermission) > 0 {
 		// add remaining grants with non-registered provider role
 		for _, g := range grantsGroupedByPermission {
-			g.Role = g.Permissions[0]
 			reducedGrants = append(reducedGrants, g)
 		}
 	}

--- a/core/grant/service.go
+++ b/core/grant/service.go
@@ -364,11 +364,11 @@ func (s *Service) ImportFromProvider(ctx context.Context, criteria ImportFromPro
 			// group grants for the same account (accountGrants) by provider role
 			rc := resourceConfigs[resource.Type]
 			grants = reduceGrantsByProviderRole(rc, grants)
-			for _, g := range grants {
+			for i, g := range grants {
 				key := g.PermissionsKey()
 				if existingGrant, ok := activeGrantsMap[rURN][accountSignature][key]; ok {
 					// replace imported grant values with existing grant
-					*g = *existingGrant
+					*grants[i] = *existingGrant
 
 					// remove updated grant from active grants map
 					delete(activeGrantsMap[rURN][accountSignature], key)
@@ -434,7 +434,7 @@ func reduceGrantsByProviderRole(rc *domain.ResourceConfig, grants []*domain.Gran
 
 	for roleID, permissionsByRole := range rolePermissionsMap {
 		if containing, headIndex := utils.SubsliceExists(allGrantPermissions, permissionsByRole); containing {
-			sampleGrant := grantsGroupedByPermission[allGrantPermissions[0]]
+			sampleGrant := grantsGroupedByPermission[allGrantPermissions[headIndex]]
 			sampleGrant.Role = roleID
 			sampleGrant.Permissions = permissionsByRole
 			reducedGrants = append(reducedGrants, sampleGrant)

--- a/domain/grant.go
+++ b/domain/grant.go
@@ -125,6 +125,7 @@ func (ae AccessEntry) ToGrant(resource Resource) Grant {
 		AccountID:        ae.AccountID,
 		AccountType:      ae.AccountType,
 		Owner:            SystemActorName,
+		Role:             ae.Permission,
 		Permissions:      []string{ae.Permission},
 		Source:           GrantSourceImport,
 		IsPermanent:      true,

--- a/domain/provider.go
+++ b/domain/provider.go
@@ -35,6 +35,16 @@ type Role struct {
 	Permissions []interface{} `json:"permissions" yaml:"permissions" validate:"required"`
 }
 
+// GetOrderedPermissions returns the permissions as a string slice
+func (r Role) GetOrderedPermissions() []string {
+	permissions := []string{}
+	for _, p := range r.Permissions {
+		permissions = append(permissions, fmt.Sprintf("%s", p))
+	}
+	sort.Strings(permissions)
+	return permissions
+}
+
 // PolicyConfig is the configuration that defines which policy is being used in the provider
 type PolicyConfig struct {
 	ID      string `json:"id" yaml:"id" validate:"required"`
@@ -47,20 +57,6 @@ type ResourceConfig struct {
 	Filter string        `json:"filter" yaml:"filter"`
 	Policy *PolicyConfig `json:"policy" yaml:"policy"`
 	Roles  []*Role       `json:"roles" yaml:"roles" validate:"required"`
-}
-
-// GetRolePermissionsMap returns map[Role.ID][]PermissionStr
-func (rc ResourceConfig) GetRolePermissionsMap() map[string][]string {
-	rolePermissions := map[string][]string{}
-	for _, r := range rc.Roles {
-		var permissionsStr []string
-		for _, v := range r.Permissions {
-			permissionsStr = append(permissionsStr, fmt.Sprintf("%s", v))
-		}
-		sort.Strings(permissionsStr)
-		rolePermissions[r.ID] = permissionsStr
-	}
-	return rolePermissions
 }
 
 // AppealConfig is the policy configuration of the appeal

--- a/internal/store/postgres/model/resource.go
+++ b/internal/store/postgres/model/resource.go
@@ -48,6 +48,7 @@ func (r *Resource) BeforeCreate(tx *gorm.DB) error {
 		},
 		DoUpdates: clause.AssignmentColumns([]string{"name", "details", "updated_at", "is_deleted", "parent_id"}),
 	})
+
 	return nil
 }
 


### PR DESCRIPTION
Changes:
- upsert resources individually in `grantRepository.BulkUpsert` to avoid duplicate resources on upsert
- fix nil pointer exception issue on `sampleGrant` initialization when grouping imported grants by provider role
- prioritize role with most permissions when grouping imported grants