### PR TITLE
feat: allow policy iam config to retrieve value using expression

### DIFF
--- a/core/appeal/service.go
+++ b/core/appeal/service.go
@@ -999,47 +999,51 @@ func getPolicy(a *domain.Appeal, p *domain.Provider, policiesMap map[string]map[
 }
 
 func (s *Service) addCreatorDetails(a *domain.Appeal, p *domain.Policy) error {
-	if p.IAM != nil {
-		iamConfig, err := s.iam.ParseConfig(p.IAM)
-		if err != nil {
-			return fmt.Errorf("parsing iam config: %w", err)
-		}
-		iamClient, err := s.iam.GetClient(iamConfig)
-		if err != nil {
-			return fmt.Errorf("getting iam client: %w", err)
-		}
-
-		userDetails, err := iamClient.GetUser(a.CreatedBy)
-		if err != nil {
-			return fmt.Errorf("fetching creator's user iam: %w", err)
-		}
-
-		var creator map[string]interface{}
-		if userDetailsMap, ok := userDetails.(map[string]interface{}); ok {
-			if p.IAM.Schema != nil {
-				creator = map[string]interface{}{}
-				for schemaKey, targetKey := range p.IAM.Schema {
-					if strings.Contains(targetKey, "$response") {
-						params := map[string]interface{}{
-							"response": userDetailsMap,
-						}
-						v, err := evaluator.Expression(targetKey).EvaluateWithVars(params)
-						if err != nil {
-							return fmt.Errorf("evaluating expression: %w", err)
-						}
-						creator[schemaKey] = v
-					} else {
-						creator[schemaKey] = userDetailsMap[targetKey]
-					}
-				}
-			} else {
-				creator = userDetailsMap
-			}
-		}
-
-		a.Creator = creator
+	if p.IAM == nil {
+		return nil
 	}
 
+	iamConfig, err := s.iam.ParseConfig(p.IAM)
+	if err != nil {
+		return fmt.Errorf("parsing iam config: %w", err)
+	}
+	iamClient, err := s.iam.GetClient(iamConfig)
+	if err != nil {
+		return fmt.Errorf("getting iam client: %w", err)
+	}
+
+	userDetails, err := iamClient.GetUser(a.CreatedBy)
+	if err != nil {
+		return fmt.Errorf("fetching creator's user iam: %w", err)
+	}
+
+	userDetailsMap, ok := userDetails.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	if p.IAM.Schema == nil {
+		a.Creator = userDetailsMap
+		return nil
+	}
+
+	creator := map[string]interface{}{}
+	for schemaKey, targetKey := range p.IAM.Schema {
+		if strings.Contains(targetKey, "$response") {
+			params := map[string]interface{}{
+				"response": userDetailsMap,
+			}
+			v, err := evaluator.Expression(targetKey).EvaluateWithVars(params)
+			if err != nil {
+				return fmt.Errorf("evaluating expression: %w", err)
+			}
+			creator[schemaKey] = v
+		} else {
+			creator[schemaKey] = userDetailsMap[targetKey]
+		}
+	}
+
+	a.Creator = creator
 	return nil
 }
 


### PR DESCRIPTION
Changes:
- support expression evaluation in policy iam schema config
   example:
   ```json
   // response from identity service
   {"managers": [{"email": "user@example.com"}]}
   ```
   ```yaml
   # policy
   iam:
     ...
     schema:
       managers: $response.managers[0].email
   ```
   ```go
   // appeal result
   Appeal{
     ...
     Creator: map[string]interface{}{
       "managers": "user@example.com"
     },
   }
   ```