### PR TITLE
fix(gcs): exclude deleted principals

### DIFF
--- a/plugins/providers/gcs/client.go
+++ b/plugins/providers/gcs/client.go
@@ -95,6 +95,9 @@ func (c *gcsClient) ListAccess(ctx context.Context, resources []*domain.Resource
 
 		for _, role := range policy.Roles() {
 			for _, member := range policy.Members(role) {
+				if strings.HasPrefix(member, "deleted:") {
+					continue
+				}
 				accountType, accountID, err := parseMember(member)
 				if err != nil {
 					return nil, err

--- a/plugins/providers/gcs/client.go
+++ b/plugins/providers/gcs/client.go
@@ -13,10 +13,6 @@ import (
 	"google.golang.org/api/option"
 )
 
-var (
-	excludedAccountTypesOnImport = []string{"allUsers", "allAuthenticatedUsers", "projectOwner", "projectEditor", "projectViewer"}
-)
-
 type gcsClient struct {
 	client    *storage.Client
 	projectID string
@@ -105,7 +101,7 @@ func (c *gcsClient) ListAccess(ctx context.Context, resources []*domain.Resource
 				}
 
 				// exclude unsupported account types
-				if utils.ContainsString(excludedAccountTypesOnImport, accountType) {
+				if !utils.ContainsString(AllowedAccountTypes, accountType) {
 					continue
 				}
 

--- a/plugins/providers/gcs/config.go
+++ b/plugins/providers/gcs/config.go
@@ -28,6 +28,15 @@ const (
 	AccountTypeDomain         = "domain"
 )
 
+var (
+	AllowedAccountTypes = []string{
+		AccountTypeUser,
+		AccountTypeServiceAccount,
+		AccountTypeGroup,
+		AccountTypeDomain,
+	}
+)
+
 type Config struct {
 	ProviderConfig *domain.ProviderConfig
 


### PR DESCRIPTION
fix the following error when parsing principal identifier from gcs iamPolicy
```
failed to import access: fetching access from provider: invalid bucket access member signature "deleted:user:example@example.com?uid=123456"
```