### PR TITLE
test: add short flag for store unit test because it's using dockertest for integration tests

### DIFF
--- a/internal/store/postgres/activity_repository_test.go
+++ b/internal/store/postgres/activity_repository_test.go
@@ -28,6 +28,10 @@ type ActivityRepositoryTestSuite struct {
 }
 
 func TestActivityRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	suite.Run(t, new(ActivityRepositoryTestSuite))
 }
 

--- a/internal/store/postgres/appeal_repository_test.go
+++ b/internal/store/postgres/appeal_repository_test.go
@@ -389,5 +389,9 @@ func (s *AppealRepositoryTestSuite) TestUpdate() {
 }
 
 func TestAppealRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	suite.Run(t, new(AppealRepositoryTestSuite))
 }

--- a/internal/store/postgres/approval_repository_test.go
+++ b/internal/store/postgres/approval_repository_test.go
@@ -26,6 +26,10 @@ type ApprovalRepositoryTestSuite struct {
 }
 
 func TestApprovalRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	suite.Run(t, new(ApprovalRepositoryTestSuite))
 }
 

--- a/internal/store/postgres/grant_repository_test.go
+++ b/internal/store/postgres/grant_repository_test.go
@@ -30,6 +30,10 @@ type GrantRepositoryTestSuite struct {
 }
 
 func TestGrantRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	suite.Run(t, new(GrantRepositoryTestSuite))
 }
 

--- a/internal/store/postgres/policy_repository_test.go
+++ b/internal/store/postgres/policy_repository_test.go
@@ -204,5 +204,9 @@ func (s *PolicyRepositoryTestSuite) TestGetOne() {
 }
 
 func TestPolicyRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	suite.Run(t, new(PolicyRepositoryTestSuite))
 }

--- a/internal/store/postgres/provider_repository_test.go
+++ b/internal/store/postgres/provider_repository_test.go
@@ -377,5 +377,9 @@ func (s *ProviderRepositoryTestSuite) TestDelete() {
 }
 
 func TestProviderRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	suite.Run(t, new(ProviderRepositoryTestSuite))
 }

--- a/internal/store/postgres/resource_repository_test.go
+++ b/internal/store/postgres/resource_repository_test.go
@@ -420,5 +420,9 @@ func (s *ResourceRepositoryTestSuite) getTestResources() []*domain.Resource {
 }
 
 func TestResourceRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	suite.Run(t, new(ResourceRepositoryTestSuite))
 }


### PR DESCRIPTION
try to solve issue #354 so that people using Guardian will have options of disabling store package test which uses dockertest that requires connecting to `/var/run/docker.sock`

```sh
$ go test -count=1 -race -v -short github.com/odpf/guardian/internal/store/postgres
=== RUN   TestActivityRepository
    activity_repository_test.go:32:
--- SKIP: TestActivityRepository (0.00s)
=== RUN   TestAppealRepository
    appeal_repository_test.go:393:
--- SKIP: TestAppealRepository (0.00s)
=== RUN   TestApprovalRepository
    approval_repository_test.go:30:
--- SKIP: TestApprovalRepository (0.00s)
=== RUN   TestGrantRepository
    grant_repository_test.go:34:
--- SKIP: TestGrantRepository (0.00s)
=== RUN   TestPolicyRepository
    policy_repository_test.go:208:
--- SKIP: TestPolicyRepository (0.00s)
=== RUN   TestProviderRepository
    provider_repository_test.go:381:
--- SKIP: TestProviderRepository (0.00s)
=== RUN   TestResourceRepository
    resource_repository_test.go:424:
--- SKIP: TestResourceRepository (0.00s)
PASS
ok  	github.com/odpf/guardian/internal/store/postgres	0.691s
```