### PR TITLE
feat: convert duration to days and appeal rejection notification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,22 +21,22 @@ format:
 	@echo "Running go fmt..."
 	@go fmt
 
-lint:
+lint: ## Lint checker
 	@echo "Running lint checks using golangci-lint..."
 	@golangci-lint run
 
-clean: tidy
+clean: tidy ## Clean the build artifacts
 	@echo "Cleaning up build directories..."
 	@rm -rf $coverage.out ${BUILD_DIR}
 
-test:
+test:  ## Run the tests
 	go test ./... -race -coverprofile=coverage.out
 
-coverage: test
+coverage: test ## Print the code coverage
 	@echo "Generating coverage report..."
 	@go tool cover -html=coverage.out
 
-build:
+build: ## Build the guardian binary
 	@echo "Building guardian version ${VERSION}..."
 	go build -ldflags "-X ${NAME}/core.Version=${VERSION} -X ${NAME}/core.BuildCommit=${COMMIT}" -o dist/guardian .
 	@echo "Build complete"
@@ -50,21 +50,21 @@ vet:
 download:
 	@go mod download
 
-generate:
+generate: ## Run all go generate in the code base
 	@echo "Running go generate..."
 	go generate ./...
 
-config:
+config: ## Generate the sample config file
 	@echo "Initializing sample server config..."
 	@cp internal/server/config.yaml config.yaml
 
-proto:
+proto: ## Generate the protobuf files
 	@echo "Generating protobuf from odpf/proton"
 	@echo " [info] make sure correct version of dependencies are installed using 'make install'"
 	@buf generate https://github.com/odpf/proton/archive/${PROTON_COMMIT}.zip#strip_components=1 --template buf.gen.yaml --path odpf/guardian
 	@echo "Protobuf compilation finished"
 
-setup:
+setup: ## Install all the dependencies
 	@echo "Installing dependencies..."
 	go mod tidy
 	go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
@@ -75,3 +75,6 @@ setup:
 	go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.5.0
 	go get github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.5.0
 	go get github.com/bufbuild/buf/cmd/buf@v0.54.1
+
+help: ## Display this help message
+	@cat $(MAKEFILE_LIST) | grep -e "^[a-zA-Z_\-]*: *.*## *" | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/core/provider/service.go
+++ b/core/provider/service.go
@@ -525,16 +525,15 @@ func (s *Service) getResources(ctx context.Context, p *domain.Provider) ([]*doma
 	for _, r := range flattenedProviderResources {
 		for _, er := range existingGuardianResources {
 			if er.URN == r.URN {
-				existingMetadata := er.Details
-				if existingMetadata != nil {
+				if existingDetails := er.Details; existingDetails != nil {
 					if r.Details != nil {
-						for key, value := range existingMetadata {
+						for key, value := range existingDetails {
 							if _, ok := r.Details[key]; !ok {
 								r.Details[key] = value
 							}
 						}
 					} else {
-						r.Details = existingMetadata
+						r.Details = existingDetails
 					}
 				}
 

--- a/core/provider/service_test.go
+++ b/core/provider/service_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/odpf/guardian/core/provider"
 	providermocks "github.com/odpf/guardian/core/provider/mocks"
+	"github.com/odpf/guardian/core/resource"
 	"github.com/odpf/guardian/domain"
 	"github.com/odpf/salt/log"
 	"github.com/stretchr/testify/mock"
@@ -349,20 +352,77 @@ func (s *ServiceTestSuite) TestFetchResources() {
 	})
 
 	s.Run("should upsert all resources on success", func() {
-		s.mockProviderRepository.EXPECT().Find(mock.AnythingOfType("*context.emptyCtx")).Return(providers, nil).Once()
-		expectedResources := []*domain.Resource{}
-		for _, p := range providers {
-			resources := []*domain.Resource{
-				{
-					ProviderType: p.Type,
-					ProviderURN:  p.URN,
+		existingResources := []*domain.Resource{
+			{
+				ID:           "1",
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-1",
+				Details: map[string]interface{}{
+					"owner": "test-owner",
+					resource.ReservedDetailsKeyMetadata: map[string]interface{}{
+						"labels": map[string]string{
+							"foo": "bar",
+							"baz": "qux",
+						},
+						"x": "y",
+					},
 				},
-			}
-			s.mockProvider.On("GetResources", p.Config).Return(resources, nil).Once()
-			expectedResources = append(expectedResources, resources...)
+			},
 		}
-		s.mockResourceService.On("BulkUpsert", mock.Anything, expectedResources).Return(nil).Once()
-		s.mockResourceService.On("Find", mock.Anything, mock.Anything).Return([]*domain.Resource{}, nil).Once()
+		newResources := []*domain.Resource{
+			{
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-1",
+				Details: map[string]interface{}{
+					resource.ReservedDetailsKeyMetadata: map[string]interface{}{
+						"labels": map[string]string{
+							"new-key": "new-value",
+						},
+					},
+				},
+			},
+			{
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-2",
+			},
+		}
+		expectedResources := []*domain.Resource{
+			{
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-1",
+				Details: map[string]interface{}{
+					"owner": "test-owner", // owner not changed
+					resource.ReservedDetailsKeyMetadata: map[string]interface{}{ // metadata updated
+						"labels": map[string]string{
+							"new-key": "new-value",
+						},
+					},
+				},
+			},
+			{
+				ProviderType: mockProviderType,
+				ProviderURN:  mockProvider,
+				Type:         "test-resource-type",
+				URN:          "test-resource-urn-2",
+			},
+		}
+
+		expectedProvider := providers[0]
+		s.mockProviderRepository.EXPECT().Find(mock.AnythingOfType("*context.emptyCtx")).Return([]*domain.Provider{expectedProvider}, nil).Once()
+		s.mockProvider.EXPECT().GetResources(expectedProvider.Config).Return(newResources, nil).Once()
+		s.mockResourceService.EXPECT().BulkUpsert(mock.Anything, mock.AnythingOfType("[]*domain.Resource")).
+			Run(func(_a0 context.Context, resources []*domain.Resource) {
+				s.Empty(cmp.Diff(expectedResources, resources, cmpopts.IgnoreFields(domain.Resource{}, "ID", "CreatedAt", "UpdatedAt")))
+			}).Return(nil).Once()
+		s.mockResourceService.EXPECT().Find(mock.Anything, mock.Anything).Return(existingResources, nil).Once()
 		actualError := s.service.FetchResources(context.Background())
 
 		s.Nil(actualError)

--- a/core/resource/service.go
+++ b/core/resource/service.go
@@ -13,6 +13,8 @@ const (
 	AuditKeyResourceUpdate      = "resource.update"
 	AuditKeyResourceDelete      = "resource.delete"
 	AuditKeyResourceBatchDelete = "resource.batchDelete"
+
+	ReservedDetailsKeyMetadata = "__metadata"
 )
 
 //go:generate mockery --name=repository --exported --with-expecter
@@ -88,6 +90,10 @@ func (s *Service) Update(ctx context.Context, r *domain.Resource) error {
 	if err != nil {
 		return err
 	}
+
+	// Details[ReservedDetailsKeyMetadata] is not allowed to be updated by users
+	// value for this field should only set by the provider on FetchResources
+	delete(r.Details, ReservedDetailsKeyMetadata)
 
 	if err := mergo.Merge(r, existingResource); err != nil {
 		return err

--- a/domain/appeal.go
+++ b/domain/appeal.go
@@ -22,6 +22,7 @@ const (
 	SystemActorName = "system"
 
 	DefaultAppealAccountType = "user"
+	PermanentDurationLabel   = "Permanent"
 )
 
 var (

--- a/plugins/providers/bigquery/client_test.go
+++ b/plugins/providers/bigquery/client_test.go
@@ -1,0 +1,155 @@
+package bigquery_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/odpf/guardian/plugins/providers/bigquery"
+	"github.com/stretchr/testify/suite"
+	bqApi "google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/option"
+)
+
+type ClientTestSuite struct {
+	suite.Suite
+}
+
+func TestClient(t *testing.T) {
+	suite.Run(t, new(ClientTestSuite))
+}
+
+func (s *ClientTestSuite) TestGetDatasets() {
+	projectID := "test_project"
+	expectedDatasets := []*bigquery.Dataset{
+		{
+			ProjectID: projectID,
+			DatasetID: "dataset_1",
+			Labels: map[string]string{
+				"test_label": "test_value",
+			},
+		},
+		{
+			ProjectID: projectID,
+			DatasetID: "dataset_2",
+		},
+	}
+
+	isFirstPageHelper := true
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := &bqApi.DatasetList{}
+		if isFirstPageHelper {
+			res.NextPageToken = "test_next_page_token"
+			res.Datasets = []*bqApi.DatasetListDatasets{
+				{
+					Id: projectID + ":dataset_1",
+					DatasetReference: &bqApi.DatasetReference{
+						DatasetId: "dataset_1",
+						ProjectId: projectID,
+					},
+					Labels: map[string]string{
+						"test_label": "test_value",
+					},
+				},
+			}
+			isFirstPageHelper = false
+		} else { // 2nd page
+			res.Datasets = []*bqApi.DatasetListDatasets{
+				{
+					Id: projectID + ":dataset_2",
+					DatasetReference: &bqApi.DatasetReference{
+						DatasetId: "dataset_2",
+						ProjectId: projectID,
+					},
+				},
+			}
+		}
+
+		b, err := json.Marshal(res)
+		if err != nil {
+			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Write(b)
+	}))
+	defer ts.Close()
+
+	client, err := bigquery.NewBigQueryClient(projectID, option.WithoutAuthentication(), option.WithEndpoint(ts.URL))
+	s.Require().NoError(err)
+
+	datasets, err := client.GetDatasets(context.Background())
+
+	s.Nil(err)
+	s.Equal(expectedDatasets, datasets)
+}
+
+func (s *ClientTestSuite) TestGetTables() {
+	projectID := "test_project"
+	datasetID := "test_dataset"
+	expectedTables := []*bigquery.Table{
+		{
+			ProjectID: projectID,
+			DatasetID: datasetID,
+			TableID:   "table_1",
+			Labels: map[string]string{
+				"test_label": "test_value",
+			},
+		},
+		{
+			ProjectID: projectID,
+			DatasetID: datasetID,
+			TableID:   "table_2",
+		},
+	}
+
+	isFirstPageHelper := true
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := &bqApi.TableList{}
+		if isFirstPageHelper {
+			res.NextPageToken = "test_next_page_token"
+			res.Tables = []*bqApi.TableListTables{
+				{
+					Id: projectID + ":" + datasetID + ".table_1",
+					TableReference: &bqApi.TableReference{
+						ProjectId: projectID,
+						DatasetId: datasetID,
+						TableId:   "table_1",
+					},
+					Labels: map[string]string{
+						"test_label": "test_value",
+					},
+				},
+			}
+			isFirstPageHelper = false
+		} else { // 2nd page
+			res.Tables = []*bqApi.TableListTables{
+				{
+					Id: projectID + ":" + datasetID + ".table_2",
+					TableReference: &bqApi.TableReference{
+						ProjectId: projectID,
+						DatasetId: datasetID,
+						TableId:   "table_2",
+					},
+				},
+			}
+		}
+
+		b, err := json.Marshal(res)
+		if err != nil {
+			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Write(b)
+	}))
+	defer ts.Close()
+
+	client, err := bigquery.NewBigQueryClient(projectID, option.WithoutAuthentication(), option.WithEndpoint(ts.URL))
+	s.Require().NoError(err)
+
+	tables, err := client.GetTables(context.Background(), datasetID)
+
+	s.Nil(err)
+	s.Equal(expectedTables, tables)
+}

--- a/plugins/providers/bigquery/config.go
+++ b/plugins/providers/bigquery/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/odpf/guardian/domain"
 	"github.com/odpf/guardian/utils"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -132,7 +133,7 @@ func (c *Config) parseAndValidate() error {
 	}
 
 	projectID := strings.Replace(credentials.ResourceName, "projects/", "", 1)
-	client, err := newBigQueryClient(projectID, []byte(credentials.ServiceAccountKey))
+	client, err := NewBigQueryClient(projectID, option.WithCredentialsJSON([]byte(credentials.ServiceAccountKey)))
 	if err != nil {
 		return err
 	}

--- a/plugins/providers/bigquery/model.go
+++ b/plugins/providers/bigquery/model.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	bq "cloud.google.com/go/bigquery"
+	"github.com/odpf/guardian/core/resource"
 	"github.com/odpf/guardian/domain"
 )
 
@@ -19,6 +20,7 @@ const (
 type Dataset struct {
 	ProjectID string
 	DatasetID string
+	Labels    map[string]string
 }
 
 func (d *Dataset) FromDomain(r *domain.Resource) error {
@@ -32,11 +34,22 @@ func (d *Dataset) FromDomain(r *domain.Resource) error {
 }
 
 func (d *Dataset) ToDomain() *domain.Resource {
-	return &domain.Resource{
+	r := &domain.Resource{
 		Type: ResourceTypeDataset,
 		Name: d.DatasetID,
 		URN:  fmt.Sprintf("%s:%s", d.ProjectID, d.DatasetID),
 	}
+
+	if d.Labels != nil {
+		if r.Details == nil {
+			r.Details = make(map[string]interface{})
+		}
+		r.Details[resource.ReservedDetailsKeyMetadata] = map[string]interface{}{
+			"labels": d.Labels,
+		}
+	}
+
+	return r
 }
 
 // Table is a reference to a BigQuery table
@@ -44,6 +57,7 @@ type Table struct {
 	ProjectID string
 	DatasetID string
 	TableID   string
+	Labels    map[string]string
 }
 
 func (t *Table) FromDomain(r *domain.Resource) error {
@@ -62,11 +76,22 @@ func (t *Table) FromDomain(r *domain.Resource) error {
 }
 
 func (t *Table) ToDomain() *domain.Resource {
-	return &domain.Resource{
+	r := &domain.Resource{
 		Type: ResourceTypeTable,
 		Name: t.TableID,
 		URN:  fmt.Sprintf("%s:%s.%s", t.ProjectID, t.DatasetID, t.TableID),
 	}
+
+	if t.Labels != nil {
+		if r.Details == nil {
+			r.Details = make(map[string]interface{})
+		}
+		r.Details[resource.ReservedDetailsKeyMetadata] = map[string]interface{}{
+			"labels": t.Labels,
+		}
+	}
+
+	return r
 }
 
 type datasetAccessEntry bq.AccessEntry

--- a/utils/time.go
+++ b/utils/time.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/odpf/guardian/domain"
+)
+
+// GetReadableDuration returns a human-readable duration string in integer days preferably, or the original string if it's either not a valid duration or a days value is not integer.
+func GetReadableDuration(durationStr string) (string, error) {
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return durationStr, err
+	}
+
+	days := duration.Hours() / 24
+	if days > 0 {
+		if IsInteger(days) {
+			// if the duration is in integral days, return it as integer
+			return fmt.Sprintf("%dd", int(days)), nil
+		}
+
+		return durationStr, nil
+	}
+
+	return domain.PermanentDurationLabel, nil
+}

--- a/utils/time_test.go
+++ b/utils/time_test.go
@@ -1,0 +1,84 @@
+package utils
+
+import "testing"
+
+func TestGetReadableDuration(t *testing.T) {
+	type args struct {
+		durationStr string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "should return duration in integral days when input can be converted into days - 1",
+			args: args{
+				durationStr: "2160h",
+			},
+			want:    "90d",
+			wantErr: false,
+		},
+		{
+			name: "should return duration in integral days when input can be converted into days - 2",
+			args: args{
+				durationStr: "24h",
+			},
+			want:    "1d",
+			wantErr: false,
+		},
+		{
+			name: "should return duration in integral days when input can be converted into days - 3",
+			args: args{
+				durationStr: "86400s",
+			},
+			want:    "1d",
+			wantErr: false,
+		},
+		{
+			name: "should return duration same as input when input cannot be converted into days - 1",
+			args: args{
+				durationStr: "1h",
+			},
+			want:    "1h",
+			wantErr: false,
+		},
+		{
+			name: "should return duration same as input when input cannot be converted into days - 2",
+			args: args{
+				durationStr: "25h",
+			},
+			want:    "25h",
+			wantErr: false,
+		},
+		{
+			name: "should return duration same as input when input cannot be converted into days - 3",
+			args: args{
+				durationStr: "86399s",
+			},
+			want:    "86399s",
+			wantErr: false,
+		},
+		{
+			name: "should return duration same as input when input is not a valid duration",
+			args: args{
+				durationStr: "124hs",
+			},
+			want:    "124hs",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetReadableDuration(tt.args.durationStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetReadableDuration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetReadableDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,5 @@
+package utils
+
+func IsInteger(val float64) bool {
+	return val == float64(int(val))
+}


### PR DESCRIPTION
- convert duration to days if possible for slack approval notification
- send appeal rejection notification for auto rejected steps, which got auto-rejected at appeal creation time
- include labels from dataset & table when fetching resources (prevent Resource.Details["_metadata"] update from users in UpdateResource) (#372 )